### PR TITLE
Cache chrome version resolution

### DIFF
--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.1.3
+    call: google/install-chrome 2.1.4
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.1.3
+    call: google/install-chrome 2.1.4
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 2.1.3
+    call: google/install-chrome 2.1.4
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 2.1.3
+    call: google/install-chrome 2.1.4
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -68,7 +68,7 @@ By default, `google/install-chrome` supports tools that interact with Chrome in 
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.1.3
+  call: google/install-chrome 2.1.4
   with:
     chrome-version: stable
     install-chromedriver: true
@@ -117,7 +117,7 @@ You can also use tools that interact with headed Chrome. To do so, wrap your com
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.1.3
+  call: google/install-chrome 2.1.4
   with:
     chrome-version: stable
     install-chromedriver: true

--- a/google/install-chrome/mint-ci-cd.config.yml
+++ b/google/install-chrome/mint-ci-cd.config.yml
@@ -10,5 +10,5 @@ tests:
     template: mint-ci-cd.template.yml
     base:
       os: ubuntu 24.04
-      tag: 1.0
+      tag: 1.1
       arch: x86_64

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google/install-chrome
-version: 2.1.3
+version: 2.1.4
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/google/install-chrome
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -74,7 +74,9 @@ tasks:
       fi
     env:
       CHROME_VERSION: ${{ params.chrome-version }}
-    cache: ${{ params.chrome-version =~ '^\d+\.\d+\.\d+\.\d+$' }}
+    cache:
+      ttl: 1 day
+
 
   - key: install
     run: |


### PR DESCRIPTION
When resolving release channels such as `stable`, cache the version resolution for 1 day rather than resolving on every run.