### PR TITLE
When installing nodejs handle gpg error "contains no user ID"

### DIFF
--- a/nodejs/install/README.md
+++ b/nodejs/install/README.md
@@ -7,7 +7,7 @@ You'll either need to specify `node-version` or `node-version-file`
 ```yaml
 tasks:
   - key: node
-    call: nodejs/install 1.1.6
+    call: nodejs/install 1.1.7
     with:
       node-version: "21.4.0"
 ```
@@ -20,7 +20,7 @@ Or with a file named `.node-version` containing the version of node to install:
 tasks:
   - key: node
     use: code # or whichever task provides the .node-version file
-    call: nodejs/install 1.1.6
+    call: nodejs/install 1.1.7
     with:
       node-version-file: .node-version
     filter:

--- a/nodejs/install/bin/install-node
+++ b/nodejs/install/bin/install-node
@@ -49,8 +49,16 @@ for key in \
   108F52B48DB57BB0CC439B2997B01419BD92F80A \
   A363A499291CBBC940DD62E41F10027AF002F8B0 \
   ; do
-  gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ||
+  set +e
+  output=$(gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" 2>&1)
+  gpg_status=$?
+  set -e
+  echo "$output"
+
+  if [ $gpg_status -ne 0 ] || echo "$output" | grep -q "contains no user ID"; then
+    echo "Retrying with ubuntu keyserver for $key"
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"
+  fi
 done
 
 ### Install node

--- a/nodejs/install/rwx-package.yml
+++ b/nodejs/install/rwx-package.yml
@@ -1,5 +1,5 @@
 name: nodejs/install
-version: 1.1.6
+version: 1.1.7
 description: Install Node.js, the cross-platform JavaScript runtime environment
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/nodejs/install
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues


### PR DESCRIPTION
This is caused by this issue:

https://github.com/nodejs/node/issues/58904

https://github.com/nodejs/node/pull/58877

------

**Note for upgrading RWX workflows**

> [!IMPORTANT]
> If you were previously using the `mint/install-node` leaf, please change to `nodejs/install 1.1.7`

------

One of the keys used to sign nodejs releases is currently broken on one of the keyservers.

```
➜  gpg --keyserver hkps://keys.openpgp.org --recv-keys C0D6248439F1D5604AAFFB4021D900FFDB233756
gpg: key 21D900FFDB233756: no user ID
gpg: Total number processed: 1
```

`gpg` exits with `0`, but it does not import the key on this error.

Because of the exit 0, the previous implementation of the script did not try the other keyserver. However, the other keyserver currently works.

```
➜  gpg --keyserver keyserver.ubuntu.com --recv-keys C0D6248439F1D5604AAFFB4021D900FFDB233756
gpg: key 21D900FFDB233756: "Antoine du Hamel <duhamelantoine1995@gmail.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
```