### PR TITLE
Ensure values always set from create-pull-request

### DIFF
--- a/github/create-pull-request/README.md
+++ b/github/create-pull-request/README.md
@@ -45,7 +45,7 @@ tasks:
     run: rwx packages update | tee $RWX_VALUES/update-output
 
   - key: create-pull-request
-    call: github/create-pull-request 1.0.0
+    call: github/create-pull-request 1.0.1
     use: [update-packages]
     with:
       github-token: ${{ github-apps.your-orgs-bot.token }}

--- a/github/create-pull-request/README.md
+++ b/github/create-pull-request/README.md
@@ -17,6 +17,13 @@ with repository permissions for:
 - Define a task to make the desired changes
 - Use this package to create a pull request, or update an existing one identified by the `branch-prefix`.
 
+## Output Values
+
+| key                 | description                                                                 |
+|---------------------|-----------------------------------------------------------------------------|
+| branch              | The branch for the pull request, or blank if a pull request was not created |
+| pull-request-number | The pull request number, or blank a pull request was not created            |
+
 ## Example
 
 This example uses a [cron trigger](https://www.rwx.com/docs/mint/cron-schedules) to update RWX packages once per week.

--- a/github/create-pull-request/rwx-package.yml
+++ b/github/create-pull-request/rwx-package.yml
@@ -1,5 +1,5 @@
 name: github/create-pull-request
-version: 1.0.0
+version: 1.0.1
 description: Creates a pull request
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/create-pull-request
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -29,6 +29,9 @@ tasks:
     use: [gh-cli]
     cache: false
     run: |
+      # ensure these values are always present
+      touch $RWX_VALUES/{branch,pull-request-number}
+
       git_status=$(git status --porcelain)
       if [ -n "$git_status" ]; then
         git add --all


### PR DESCRIPTION
Without this, calling `.values` on the output from the package may not resolve, but there's no way for a downstream task to know whether or not they'll resolve.