### PR TITLE
[nodejs/install] Update signing keys

### DIFF
--- a/nodejs/install/README.md
+++ b/nodejs/install/README.md
@@ -7,7 +7,7 @@ You'll either need to specify `node-version` or `node-version-file`
 ```yaml
 tasks:
   - key: node
-    call: nodejs/install 1.1.8
+    call: nodejs/install 1.1.9
     with:
       node-version: "21.4.0"
 ```
@@ -20,7 +20,7 @@ Or with a file named `.node-version` containing the version of node to install:
 tasks:
   - key: node
     use: code # or whichever task provides the .node-version file
-    call: nodejs/install 1.1.8
+    call: nodejs/install 1.1.9
     with:
       node-version-file: .node-version
     filter:

--- a/nodejs/install/bin/install-node
+++ b/nodejs/install/bin/install-node
@@ -34,32 +34,7 @@ sudo apt-get update
 sudo apt-get install gnupg xz-utils
 sudo apt-get clean
 
-# Add known signing keys. See https://github.com/nodejs/node#release-keys
-for key in \
-  C0D6248439F1D5604AAFFB4021D900FFDB233756 \
-  4ED778F539E3634C779C87C6D7062848A1AB005C \
-  141F07595B7B3FFE74309A937405533BE57C7D57 \
-  74F12602B6F1C4E913FAA37AD3A89613643B6201 \
-  DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-  CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
-  8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-  C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
-  C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-  108F52B48DB57BB0CC439B2997B01419BD92F80A \
-  A363A499291CBBC940DD62E41F10027AF002F8B0 \
-  ; do
-  set +e
-  output=$(gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" 2>&1)
-  gpg_status=$?
-  set -e
-  echo "$output"
-
-  if [ $gpg_status -ne 0 ] || echo "$output" | grep -q "contains no user ID"; then
-    echo "Retrying with ubuntu keyserver for $key"
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"
-  fi
-done
+curl -fsSLo "/tmp/nodejs-keyring.kbx" "https://github.com/nodejs/release-keys/raw/901fc09b83c686693be51b3c9a13578929cbc1ab/gpg/pubring.kbx"
 
 ### Install node
 
@@ -93,7 +68,7 @@ shasums_url="https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt.asc"
 
 function cleanup {
   echo "Cleaning up"
-  rm -rf "$source_dir" SHASUMS256.txt.asc
+  rm -rf "$source_dir" SHASUMS256.txt.asc /tmp/nodejs-keyring.kbx
 }
 trap cleanup EXIT
 
@@ -108,7 +83,7 @@ curl --fail-with-body -o SHASUMS256.txt.asc "$shasums_url"
 cat SHASUMS256.txt.asc
 
 set +e
-gpg --verify SHASUMS256.txt.asc
+gpgv --keyring="/tmp/nodejs-keyring.kbx" < SHASUMS256.txt.asc
 gpg_exit=$?
 set -e
 if [[ $gpg_exit != 0 ]]; then
@@ -117,7 +92,7 @@ Failed to verify the GPG signature of the Node release file.
 
 Check to see if you are using the latest version of \`nodejs/install\`
 
-You can find the latest version at: https://cloud.rwx.com/leaves
+You can find the latest version at: https://www.rwx.com/docs/mint/packages/nodejs/install
 EOF
   exit $gpg_exit
 fi

--- a/nodejs/install/rwx-ci-cd.template.yml
+++ b/nodejs/install/rwx-ci-cd.template.yml
@@ -22,17 +22,17 @@
   use: test-version-file
   run: node --version | grep '20\.13\.1'
 
-- key: install-22-10-0
+- key: install-22-18-0
   call: $LEAF_DIGEST
   with:
-    node-version: "22.10.0"
+    node-version: "22.18.0"
 
-- key: test-install-22-10-0
-  use: install-22-10-0
-  run: node --version | grep '22\.10\.0'
+- key: test-install-22-18-0
+  use: install-22-18-0
+  run: node --version | grep '22\.18\.0'
 
 - key: test-npm-install-g
-  use: install-22-10-0
+  use: install-22-18-0
   run: |
     npm install -g yaml
     npm root -g > $MINT_ENV/NODE_PATH

--- a/nodejs/install/rwx-package.yml
+++ b/nodejs/install/rwx-package.yml
@@ -1,5 +1,5 @@
 name: nodejs/install
-version: 1.1.8
+version: 1.1.9
 description: Install Node.js, the cross-platform JavaScript runtime environment
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/nodejs/install
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues


### PR DESCRIPTION
Pulling this from the `nodejs/release-keys` repo rather than from keyservers, which will help with reliability in case something like this happens again:

https://www.rwx.com/blog/nodejs-maintainer-lost-their-keys