### PR TITLE
Install prebuilt Erlang from hex.pm.

### DIFF
--- a/erlang/install/README.md
+++ b/erlang/install/README.md
@@ -5,12 +5,12 @@ To install Erlang:
 ```yaml
 tasks:
   - key: erlang
-    call: erlang/install 1.0.8
+    call: erlang/install 1.1.0
     with:
-      erlang-version: 26.2.3
+      erlang-version: 28.1
 ```
 
 ## Supported Versions
 
-This leaf installs Erlang using precompiled binaries available from Erlang Solutions.
-See [their downloads page](https://www.erlang-solutions.com/downloads/) for supported versions.
+This leaf installs Erlang using precompiled binaries available from [Hex](https://hex.pm).
+See [their documentation](https://github.com/hexpm/bob?tab=readme-ov-file#erlang-builds) for supported versions.

--- a/erlang/install/rwx-ci-cd.ubuntu-22-04.yml
+++ b/erlang/install/rwx-ci-cd.ubuntu-22-04.yml
@@ -1,15 +1,3 @@
-- key: install-25-0-3
-  call: $LEAF_DIGEST
-  with:
-    erlang-version: 25.0.3
-
-- key: install-25-0-3--assert
-  use: install-25-0-3
-  run: |
-    cat "/usr/lib/erlang/releases/25/OTP_VERSION" | tee /dev/stderr | grep "^25\.0\.3$"
-
-    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^25\.0\.3$"
-
 - key: install-26-2-3
   call: $LEAF_DIGEST
   with:
@@ -21,3 +9,15 @@
     cat "/usr/lib/erlang/releases/26/OTP_VERSION" | tee /dev/stderr | grep "^26\.2\.3$"
 
     erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^26\.2\.3$"
+
+- key: install-28-1
+  call: $LEAF_DIGEST
+  with:
+    erlang-version: '28.1'
+
+- key: install-28-1--assert
+  use: install-28-1
+  run: |
+    cat "/usr/lib/erlang/releases/28/OTP_VERSION" | tee /dev/stderr | grep "^28\.1$"
+
+    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^28\.1$"

--- a/erlang/install/rwx-ci-cd.ubuntu-24-04.yml
+++ b/erlang/install/rwx-ci-cd.ubuntu-24-04.yml
@@ -1,11 +1,11 @@
-- key: install-27-3
+- key: install-28-1
   call: $LEAF_DIGEST
   with:
-    erlang-version: '27.3'
+    erlang-version: '28.1'
 
-- key: install-27-3--assert
-  use: install-27-3
+- key: install-28-1--assert
+  use: install-28-1
   run: |
-    cat "/usr/lib/erlang/releases/27/OTP_VERSION" | tee /dev/stderr | grep "^27\.3$"
+    cat "/usr/lib/erlang/releases/28/OTP_VERSION" | tee /dev/stderr | grep "^28\.1$"
 
-    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^27\.3$"
+    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^28\.1$"

--- a/erlang/install/rwx-package.yml
+++ b/erlang/install/rwx-package.yml
@@ -1,5 +1,5 @@
 name: erlang/install
-version: 1.0.8
+version: 1.1.0
 description: Install Erlang, a programming language used to build massively scalable soft real-time systems with requirements on high availability
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/erlang/install
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -13,13 +13,8 @@ tasks:
   - key: install
     run: |
       source "$MINT_LEAF_PATH/mint-utils.sh"
-      if ! mint_os_package_manager_in apt; then
-        echo "Unsupported operating system or package manager \`$(mint_os_package_manager)\`" > "$(mktemp "$MINT_ERRORS/error-XXXX")"
-        exit 1
-      fi
-
-      if [ "$(uname -p)" != "x86_64" ]; then
-        echo "Unsupported architecture \`$(uname -p)\`" > "$(mktemp "$MINT_ERRORS/error-XXXX")"
+      if [ "$(mint_os_name)" != "ubuntu" ]; then
+        echo "Unsupported operating system \`$(mint_os_name)\`" | tee "$(mktemp "$MINT_ERRORS/error-XXXX")"
         exit 1
       fi
 
@@ -33,21 +28,57 @@ tasks:
       sudo apt-get install libsctp1 "$ncurses_package"
       sudo apt-get clean
 
-      escaped_arch=$(mint_arch_amd)
-      if [ "$escaped_arch" == "aarch64" ]; then
-        escaped_arch="arm64"
+      OTP_OS=$(mint_os_name)
+      OTP_OS_VERSION=$(mint_os_version)
+      OTP_ARCH=$(mint_arch_amd)
+      if [ "$OTP_ARCH" == "aarch64" ]; then
+        OTP_ARCH="arm64"
       fi
 
-      file="esl-erlang_${ERLANG_VERSION}-1~$(mint_os_name)~$(mint_os_codename)_${escaped_arch}.deb"
-      url="https://binaries2.erlang-solutions.com/$(mint_os_name)/pool/contrib/e/esl-erlang/$file"
-      echo "Resolved source URL: $url"
-      curl -fO "$url"
-      sudo dpkg -i "$file"
-      rm "$file"
+      base_url="https://builds.hex.pm/builds/otp/${OTP_ARCH}/${OTP_OS}-${OTP_OS_VERSION}"
+      builds_url="${base_url}/builds.txt"
+
+      tmpdir="$(mktemp -d)"
+      trap 'rm -rf "${tmpdir}"' EXIT
+
+      build_line="$(curl -fsSL "${builds_url}" | grep "^OTP-${ERLANG_VERSION} ")"
+      if [ -z "${build_line}" ]; then
+        echo "Unable to find OTP-${ERLANG_VERSION} in ${builds_url}" | tee "$(mktemp "$MINT_ERRORS/error-XXXX")"
+        exit 1
+      fi
+
+      read -r -a fields <<< "${build_line}"
+      expected_sha256="${fields[3]:-}"
+
+      archive_name="OTP-${ERLANG_VERSION}.tar.gz"
+      archive_url="${base_url}/${archive_name}"
+      archive_path="${tmpdir}/${archive_name}"
+
+      curl -fsSL "${archive_url}" -o "${archive_path}"
+
+      if [ -n "${expected_sha256}" ]; then
+        computed_sha="$(sha256sum "${archive_path}" | awk '{print $1}')"
+        if [ "${computed_sha}" != "${expected_sha256}" ]; then
+          echo "Checksum mismatch for ${archive_name}: expected ${expected_sha256}, got ${computed_sha}" >&2
+          exit 1
+        fi
+      else
+        echo "Skipping checksum verification for ${archive_name}; no SHA256 provided in builds listing" >&2
+      fi
+
+      ERL_ROOT="/usr/lib/erlang"
+      sudo mkdir -p "$ERL_ROOT"
+      sudo chown "$(id -u):$(id -g)" "$ERL_ROOT"
+      tar -xzf "${archive_path}" -C "${ERL_ROOT}" --strip-components=1
+
+      "${ERL_ROOT}/Install" -minimal "${ERL_ROOT}"
+      echo "${ERL_ROOT}/bin" > $MINT_ENV/PATH
+      export PATH="${ERL_ROOT}/bin:${PATH}"
 
       major_version=$(echo "$ERLANG_VERSION" | cut -d. -f1)
-      cat "/usr/lib/erlang/releases/$major_version/OTP_VERSION" | tee /dev/stderr | grep "^${ERLANG_VERSION}$"
-
+      cat "${ERL_ROOT}/releases/$major_version/OTP_VERSION" | tee /dev/stderr | grep "^${ERLANG_VERSION}$"
       erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^${ERLANG_VERSION}$"
+
+      echo "Installed OTP-${ERLANG_VERSION} to ${ERL_ROOT}"
     env:
       ERLANG_VERSION: ${{ params.erlang-version }}


### PR DESCRIPTION
This change allows us to install Erlang versions that are not available from the previous prebuilt binary provider, Erlang Solutions.