### PR TITLE
Remove 1-1 suffix

### DIFF
--- a/ruby/install/README.md
+++ b/ruby/install/README.md
@@ -9,7 +9,7 @@ If your project has a `.ruby-version` file:
 ```yaml
 tasks:
   - key: ruby
-    call: ruby/install 1.2.10
+    call: ruby/install 1.2.11
     with:
       ruby-version-file: .ruby-version
     filter: [.ruby-version]
@@ -24,7 +24,7 @@ If your project does not have a `.ruby-version` file, you can specify the versio
 ```yaml
 tasks:
   - key: ruby
-    call: ruby/install 1.2.10
+    call: ruby/install 1.2.11
     with:
       ruby-version: 3.4.6
 ```

--- a/ruby/install/rwx-ci-cd.config.yml
+++ b/ruby/install/rwx-ci-cd.config.yml
@@ -1,26 +1,26 @@
 tests:
-  - key: ubuntu-22-04-x86-64-1-1
+  - key: ubuntu-22-04-x86-64
     template: rwx-ci-cd.template.yml
     base:
       os: ubuntu 22.04
       tag: 1.2
       arch: x86_64
 
-  - key: ubuntu-22-04-arm64-1-1
+  - key: ubuntu-22-04-arm64
     template: rwx-ci-cd.template.yml
     base:
       os: ubuntu 22.04
       tag: 1.2
       arch: arm64
 
-  - key: ubuntu-24-04-x86-64-1-2
+  - key: ubuntu-24-04-x86-64
     template: rwx-ci-cd.template.yml
     base:
       os: ubuntu 24.04
       tag: 1.2
       arch: x86_64
 
-  - key: ubuntu-24-04-arm64-1-2
+  - key: ubuntu-24-04-arm64
     template: rwx-ci-cd.template.yml
     base:
       os: ubuntu 24.04

--- a/ruby/install/rwx-package.yml
+++ b/ruby/install/rwx-package.yml
@@ -1,5 +1,5 @@
 name: ruby/install
-version: 1.2.10
+version: 1.2.11
 description: Install Ruby, a dynamic programming language with a focus on simplicity and productivity
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/ruby/install
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues


### PR DESCRIPTION
I think the 1-1 suffix is supposed to correspond to the 1.1 base image tag. But we build across 2 versions of ubuntu, 2 architectures, and just 1 tag.