### PR TITLE
Extract the os ID and VERSION_ID as RWX_IMAGE/os

### DIFF
--- a/rwx/bootstrap/bootstrap.sh
+++ b/rwx/bootstrap/bootstrap.sh
@@ -13,12 +13,15 @@ docker pull ${IMAGE}
 containerId=$(docker create ${IMAGE})
 docker export "$containerId" | sudo tar -x -C image -f - -p
 
-echo root | tee ${RWX_IMAGE}/user
+printf '%s\n' root | tee ${RWX_IMAGE}/user
+
+. image/etc/os-release
+printf '%s\n' "${ID} ${VERSION_ID}" | tee ${RWX_IMAGE}/os
 
 if [ -f image/bin/bash ]; then
-  echo "/bin/bash -l -e -o pipefail" | tee ${RWX_IMAGE}/shell
+  printf '%s\n' "/bin/bash -l -e -o pipefail" | tee ${RWX_IMAGE}/shell
 else
-  echo "/bin/sh -l -e" | tee ${RWX_IMAGE}/shell
+  printf '%s\n' "/bin/sh -l -e" | tee ${RWX_IMAGE}/shell
 fi
 
 ${SCRIPT_DIR}/extract-env.sh "$containerId" ${RWX_ENV}

--- a/rwx/bootstrap/rwx-package.yml
+++ b/rwx/bootstrap/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/bootstrap
-version: 1.1.0
+version: 1.2.0
 description: Used internally in RWX to bootstrap base images
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/bootstrap
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues


### PR DESCRIPTION
We'll use this as metadata in subsequent tasks (for things like partitioning the tool cache)