### PR TITLE
Configure git committer identity in create-pull-request

### DIFF
--- a/github/create-pull-request/README.md
+++ b/github/create-pull-request/README.md
@@ -55,7 +55,7 @@ tasks:
     run: rwx packages update | tee $RWX_VALUES/update-output
 
   - key: create-pull-request
-    call: github/create-pull-request 1.0.5
+    call: github/create-pull-request 1.0.6
     use: [update-packages]
     with:
       github-token: ${{ github-apps.your-orgs-bot.token }}

--- a/github/create-pull-request/rwx-package.yml
+++ b/github/create-pull-request/rwx-package.yml
@@ -1,5 +1,5 @@
 name: github/create-pull-request
-version: 1.0.5
+version: 1.0.6
 description: Creates a pull request
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/create-pull-request
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -23,7 +23,7 @@ outputs:
 
 tasks:
   - key: gh-cli
-    call: github/install-cli 1.0.8
+    call: github/install-cli 1.0.10
 
   - key: create-or-update-pull-request
     use: [gh-cli]
@@ -34,6 +34,12 @@ tasks:
 
       git_status=$(git status --porcelain)
       if [ -n "$git_status" ]; then
+        viewer=$(gh api graphql -f query='{ viewer { databaseId login } }')
+        login=$(printf '%s' "$viewer" | jq -r '.data.viewer.login')
+        user_id=$(printf '%s' "$viewer" | jq -r '.data.viewer.databaseId')
+        git config user.email "${user_id}+${login}@users.noreply.github.com"
+        git config user.name "$login"
+
         git add --all
         git commit -m "$PULL_REQUEST_TITLE"
       else


### PR DESCRIPTION
### Background

- [RWX-326](https://linear.app/rwx-cloud/issue/RWX-326/create-pull-request-package-should-configure-its-own-git-committer)

### Problem

The `github/create-pull-request` package relies on `git/clone` to configure `user.email` and `user.name` in the local git config. That identity setup (at `git/clone/bin/git-clone:217-235`) only runs when `preserve-git-dir=true` AND `GITHUB_TOKEN` is non-empty.

Because `GITHUB_TOKEN` is `cache-key: excluded` in `git/clone`, the git-clone task cache can be seeded by a run that clones the same repo without `github-token` (i.e. when cloning public repos). That cached `.git/config` won't have `user.email`/`user.name`, causing `git commit` in `create-pull-request` to fail with "Author identity unknown."

This is currently breaking cron jobs that use `create-pull-request` against `rwx-cloud/rwx.git`, since the new integration test CI runs clone that repo without `github-token`.

### Solution

- `create-pull-request` now configures git committer identity itself before `git commit`, using the GitHub GraphQL API to resolve the token's associated user — the same approach `git/clone` uses.
- This runs **unconditionally**, per [our discussion in Slack](https://rwxhq.slack.com/archives/C044VB13K6G/p1775747375039369), so the token provided to the package is what we'll always use.

#### Further confirmation needed

- [x] Verify the `gh api graphql` call works with GitHub App installation tokens (the `viewer` query should return the app's bot user)

This fix was confirmed in a debug session for a failing CI run in the rwx repo.