### PR TITLE
Only use the AWS us-east-2 mirror for apt with no fallback

### DIFF
--- a/rwx/base/README.md
+++ b/rwx/base/README.md
@@ -9,5 +9,5 @@ This package applies recommended base image configuration. It currently works wi
 ```yaml
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.0.1
+  config: rwx/base 1.0.2
 ```

--- a/rwx/base/rwx-package.yml
+++ b/rwx/base/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/base
-version: 1.0.1
+version: 1.0.2
 description: The default base image configuration
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/base
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues

--- a/rwx/base/scripts/apt-mirror.sh
+++ b/rwx/base/scripts/apt-mirror.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-# Point apt at the AWS EC2 regional mirror for faster access and higher uptime,
-# with the public Ubuntu archive as a fallback URI in the same stanza so apt
-# transparently fails over on AWS-side outages.
+# Point apt at the AWS EC2 regional mirror for the archive and at
+# security.ubuntu.com (or ports.ubuntu.com on non-primary arches) for security
+# updates. This matches the default sources shipped on Canonical's EC2 AMIs.
 #
 # We write /etc/apt/sources.list.d/ubuntu.sources in deb822 format. On 24.04
 # this overwrites the default. On 20.04/22.04 the default sources live in
@@ -13,11 +13,9 @@ set -euo pipefail
 # produce "configured multiple times" warnings, and sometimes prefer the
 # public mirror over the AWS primary).
 #
-# Two-pass: first over HTTP so apt can install ca-certificates on a fresh
-# image (HTTPS would fail without ca-certificates), then rewrite to the final
-# scheme. The ports mirror (arm64 etc.) doesn't support HTTPS, so it stays on
-# HTTP for both passes; the archive mirror (amd64/i386) upgrades to HTTPS
-# after ca-certificates is installed.
+# We use HTTP (not HTTPS) so this script can run on a fresh image before
+# ca-certificates is installed. Package integrity is still verified via GPG
+# signatures regardless of transport.
 aws_apt_mirror_region="us-east-2"
 
 . /etc/os-release
@@ -26,36 +24,30 @@ arch="$(dpkg --print-architecture)"
 
 case "$arch" in
   amd64|i386)
-    primary_mirror="${aws_apt_mirror_region}.ec2.archive.ubuntu.com/ubuntu"
-    fallback_mirror="archive.ubuntu.com/ubuntu"
-    final_scheme="https"
+    archive_mirror="${aws_apt_mirror_region}.ec2.archive.ubuntu.com/ubuntu"
+    security_mirror="security.ubuntu.com/ubuntu"
     ;;
   *)
-    primary_mirror="${aws_apt_mirror_region}.ec2.ports.ubuntu.com/ubuntu-ports"
-    fallback_mirror="ports.ubuntu.com/ubuntu-ports"
-    final_scheme="http"
+    archive_mirror="${aws_apt_mirror_region}.ec2.ports.ubuntu.com/ubuntu-ports"
+    security_mirror="ports.ubuntu.com/ubuntu-ports"
     ;;
 esac
 
-write_sources() {
-  local scheme="$1"
-  mkdir -p /etc/apt/sources.list.d
-  cat > /etc/apt/sources.list.d/ubuntu.sources <<EOF
+mkdir -p /etc/apt/sources.list.d
+cat > /etc/apt/sources.list.d/ubuntu.sources <<EOF
 Types: deb
-URIs: ${scheme}://${primary_mirror}/ ${scheme}://${fallback_mirror}/
-Suites: ${codename} ${codename}-updates ${codename}-backports ${codename}-security
+URIs: http://${archive_mirror}/
+Suites: ${codename} ${codename}-updates ${codename}-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://${security_mirror}/
+Suites: ${codename}-security
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
-}
 
 if [ -f /etc/apt/sources.list ]; then
   : > /etc/apt/sources.list
 fi
-
-write_sources http
-
-apt-get update
-apt-get install -y ca-certificates
-
-write_sources "$final_scheme"


### PR DESCRIPTION
When archive.ubuntu.com is still specified as a fallback, apt will pull the lists from there whenever you run `apt-get update`. In cases like yesterday that alone was slow enough to make things fail or timeout.

Also, this just uses http unconditionally (just like EC2 instances themselves do). Given the gpg verification of apt packages there isn't really any reason for the https overhead. The nice thing now is that the apt sources file completely matches what an EC2 instance does.