### PR TITLE
prefer uname -m for portability

### DIFF
--- a/aws/install-cli/README.md
+++ b/aws/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the AWS CLI:
 ```yaml
 tasks:
   - key: aws-cli
-    call: aws/install-cli 1.0.10
+    call: aws/install-cli 1.0.11
 ```
 
 To install a specific version of the AWS CLI (only v2 of the AWS CLI is supported):
@@ -13,7 +13,7 @@ To install a specific version of the AWS CLI (only v2 of the AWS CLI is supporte
 ```yaml
 tasks:
   - key: aws-cli
-    call: aws/install-cli 1.0.10
+    call: aws/install-cli 1.0.11
     with:
       cli-version: "2.15.13"
 ```

--- a/aws/install-cli/rwx-package.yml
+++ b/aws/install-cli/rwx-package.yml
@@ -1,5 +1,5 @@
 name: aws/install-cli
-version: 1.0.10
+version: 1.0.11
 description: Install the AWS CLI
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/aws/install-cli
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -48,16 +48,16 @@ tasks:
 
       # installer zip
       if [[ -n "$CLI_VERSION" ]]; then
-        curl -o "awscliv2.zip" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -p)-$CLI_VERSION.zip"
+        curl -o "awscliv2.zip" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-$CLI_VERSION.zip"
       else
-        curl -o "awscliv2.zip" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -p).zip"
+        curl -o "awscliv2.zip" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip"
       fi
 
       # signature
       if [[ -n "$CLI_VERSION" ]]; then
-        curl -o "awscliv2.sig" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -p)-$CLI_VERSION.zip.sig"
+        curl -o "awscliv2.sig" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-$CLI_VERSION.zip.sig"
       else
-        curl -o "awscliv2.sig" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -p).zip.sig"
+        curl -o "awscliv2.sig" -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip.sig"
       fi
 
       # import the public keys

--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.1.9
+    call: google/install-chrome 2.1.10
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.1.9
+    call: google/install-chrome 2.1.10
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 2.1.9
+    call: google/install-chrome 2.1.10
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 2.1.9
+    call: google/install-chrome 2.1.10
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -68,7 +68,7 @@ By default, `google/install-chrome` supports tools that interact with Chrome in 
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.1.9
+  call: google/install-chrome 2.1.10
   with:
     chrome-version: stable
     install-chromedriver: true
@@ -117,7 +117,7 @@ You can also use tools that interact with headed Chrome. To do so, wrap your com
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.1.9
+  call: google/install-chrome 2.1.10
   with:
     chrome-version: stable
     install-chromedriver: true

--- a/google/install-chrome/rwx-package.yml
+++ b/google/install-chrome/rwx-package.yml
@@ -1,5 +1,5 @@
 name: google/install-chrome
-version: 2.1.9
+version: 2.1.10
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/google/install-chrome
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -37,7 +37,7 @@ tasks:
         exit 1
       fi
 
-      if [ "$(uname -p)" != "x86_64" ]; then
+      if [ "$(uname -m)" != "x86_64" ]; then
         echo "Google currently does not package Chrome for ARM on Linux. See [GoogleChromeLabs/chrome-for-testing#1](https://github.com/GoogleChromeLabs/chrome-for-testing/issues/1) for more information. Consider using Chromium instead of Chrome." > "$(mktemp "$RWX_ERRORS/error-XXXX")"
         exit 1
       fi

--- a/google/install-chrome/rwx-test.yml
+++ b/google/install-chrome/rwx-test.yml
@@ -1,0 +1,26 @@
+base:
+  image: ${{ init.base-image }}
+  config: ${{ init.base-config }}
+  arch: ${{ init.base-arch }}
+
+tasks:
+  - key: test-stable
+    call: ${{ init.package-digest }}
+    with:
+      chrome-version: stable
+
+  - key: test-stable--assert
+    use: test-stable
+    run: google-chrome --version | grep 'Google Chrome'
+
+  - key: test-with-chromedriver
+    call: ${{ init.package-digest }}
+    with:
+      chrome-version: stable
+      install-chromedriver: true
+
+  - key: test-with-chromedriver--assert
+    use: test-with-chromedriver
+    run: |
+      google-chrome --version | grep 'Google Chrome'
+      chromedriver --version | grep 'ChromeDriver'

--- a/rust-lang/install/README.md
+++ b/rust-lang/install/README.md
@@ -5,7 +5,7 @@ To install Rust:
 ```yaml
 tasks:
   - key: rust-lang
-    call: rust-lang/install 1.0.6
+    call: rust-lang/install 1.0.7
     with:
       rust-version: 1.83.0
 ```

--- a/rust-lang/install/rwx-package.yml
+++ b/rust-lang/install/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rust-lang/install
-version: 1.0.6
+version: 1.0.7
 description: Install Rust, a language empowering everyone to build reliable and efficient software.
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rust-lang/install
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -13,7 +13,7 @@ tasks:
   - key: install
     run: |
       # Download rustup and signature
-      rustup_url="https://static.rust-lang.org/dist/rust-${RUST_VERSION}-$(uname -p)-unknown-linux-gnu.tar.gz"
+      rustup_url="https://static.rust-lang.org/dist/rust-${RUST_VERSION}-$(uname -m)-unknown-linux-gnu.tar.gz"
       curl -o rustup.tar.gz --fail-with-body -sSL "${rustup_url}"
       curl -o rustup.tar.gz.asc --fail-with-body -sSL "${rustup_url}.asc"
 

--- a/rwx/install-abq/README.md
+++ b/rwx/install-abq/README.md
@@ -7,7 +7,7 @@ To install the ABQ CLI:
 ```yaml
 tasks:
   - key: abq
-    call: rwx/install-abq 1.1.8
+    call: rwx/install-abq 1.1.9
 ```
 
 ### ABQ Documentation

--- a/rwx/install-abq/rwx-package.yml
+++ b/rwx/install-abq/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/install-abq
-version: 1.1.8
+version: 1.1.9
 description: ABQ is a universal test runner that runs test suites in parallel. It’s the best tool for splitting test suites into parallel jobs in CI.
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-abq
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -16,7 +16,7 @@ tasks:
       tmp="$(mktemp -d)"
       curl -o "$tmp/abq" -fsSL \
         -H "Authorization: Bearer $RWX_ACCESS_TOKEN" \
-        "https://cloud.rwx.com/abq/api/releases/v1/Linux/$(uname -p)/abq?install_id=${install_id}"
+        "https://cloud.rwx.com/abq/api/releases/v1/Linux/$(uname -m)/abq?install_id=${install_id}"
       sudo install "$tmp/abq" /usr/local/bin
       rm -rf $tmp
       abq --version

--- a/rwx/install-captain/README.md
+++ b/rwx/install-captain/README.md
@@ -9,7 +9,7 @@ To install the latest version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.1.5
+    call: rwx/install-captain 1.1.6
 ```
 
 To install a specific version of the Captain CLI:
@@ -17,7 +17,7 @@ To install a specific version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.1.5
+    call: rwx/install-captain 1.1.6
     with:
       captain-version: v2.5.3
 ```

--- a/rwx/install-captain/rwx-package.yml
+++ b/rwx/install-captain/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/install-captain
-version: 1.1.5
+version: 1.1.6
 description: Captain is an open source CLI that can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more.
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-captain
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -13,7 +13,7 @@ tasks:
   - key: install
     run: |
       tmpdir="$(mktemp -d)"
-      curl -o "$tmpdir/captain" -fsSL "https://releases.captain.build/${CAPTAIN_VERSION}/linux/$(uname -p)/captain"
+      curl -o "$tmpdir/captain" -fsSL "https://releases.captain.build/${CAPTAIN_VERSION}/linux/$(uname -m)/captain"
       sudo install "$tmpdir/captain" /usr/local/bin
       rm -rf "$tmpdir"
       captain --version

--- a/rwx/install-cli/README.md
+++ b/rwx/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the RWX CLI:
 ```yaml
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.3
+    call: rwx/install-cli 4.0.4
 ```
 
 To install a specific version of the RWX CLI:
@@ -13,7 +13,7 @@ To install a specific version of the RWX CLI:
 ```yaml
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.3
+    call: rwx/install-cli 4.0.4
     with:
       cli-version: v3.7.0
 ```

--- a/rwx/install-cli/rwx-package.yml
+++ b/rwx/install-cli/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/install-cli
-version: 4.0.3
+version: 4.0.4
 description: Install the RWX CLI
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-cli
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -13,7 +13,7 @@ tasks:
   - key: install
     run: |
       tmp="$(mktemp -d)"
-      curl -o "$tmp/rwx" -fsSL "https://github.com/rwx-cloud/cli/releases/download/${CLI_VERSION_PARAM}/rwx-linux-$(uname -p)"
+      curl -o "$tmp/rwx" -fsSL "https://github.com/rwx-cloud/cli/releases/download/${CLI_VERSION_PARAM}/rwx-linux-$(uname -m)"
       sudo install "$tmp/rwx" /usr/local/bin
       rm -rf "$tmp"
       rwx --version


### PR DESCRIPTION
Prefer the usage of uname -m over uname -p for portability. Specifically with custom base images uname -p is likely to return unknown and cause package breakage.

Also added adds a test for google-chrome package.

https://man7.org/linux/man-pages/man1/uname.1.html