### PR TITLE
Don't use the security apt mirror at all for Ubuntu

### DIFF
--- a/rwx/base/README.md
+++ b/rwx/base/README.md
@@ -13,5 +13,5 @@ This package applies recommended base image configuration. It currently works wi
 ```yaml
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.0
+  config: rwx/base 1.1.1
 ```

--- a/rwx/base/rwx-package.yml
+++ b/rwx/base/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/base
-version: 1.1.0
+version: 1.1.1
 description: The default base image configuration
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/base
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues

--- a/rwx/base/scripts/apt-mirror.sh
+++ b/rwx/base/scripts/apt-mirror.sh
@@ -28,11 +28,9 @@ case "$(rwx_os_name)" in
     case "$arch" in
       amd64|i386)
         archive_mirror="${aws_apt_mirror_region}.ec2.archive.ubuntu.com/ubuntu"
-        security_mirror="security.ubuntu.com/ubuntu"
         ;;
       *)
         archive_mirror="${aws_apt_mirror_region}.ec2.ports.ubuntu.com/ubuntu-ports"
-        security_mirror="ports.ubuntu.com/ubuntu-ports"
         ;;
     esac
 
@@ -41,12 +39,6 @@ case "$(rwx_os_name)" in
 Types: deb
 URIs: http://${archive_mirror}/
 Suites: ${codename} ${codename}-updates ${codename}-backports
-Components: main universe restricted multiverse
-Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-
-Types: deb
-URIs: http://${security_mirror}/
-Suites: ${codename}-security
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF


### PR DESCRIPTION
This mirror provides security updates, which is useful, but in practice most tasks for CI that use apt are cached anyway and so aren't getting those security updates either way. This should insulate us from Canonical downtime more.