### PR TITLE
Add auto-merge and reviewer-request support to github/create-pull-request

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -2,6 +2,7 @@ language: en
 useGitignore: true
 
 words:
+  - octocat
   - OIDC
   - chromedriver
   - dockerhub

--- a/github/create-pull-request/README.md
+++ b/github/create-pull-request/README.md
@@ -11,6 +11,11 @@ with repository permissions for:
 - Contents: read and write
 - Pull Requests: read and write
 
+If you request reviews from a `org/team` slug via the `reviewers` parameter,
+the app additionally needs organization permission:
+
+- Members: read
+
 ## Instructions
 
 - Clone a git repository using the [git/clone](https://www.rwx.com/docs/packages/git/clone) package. Remember to pass `preserve-git-dir: true`.
@@ -55,11 +60,26 @@ tasks:
     run: rwx packages update | tee $RWX_VALUES/update-output
 
   - key: create-pull-request
-    call: github/create-pull-request 1.0.6
+    call: github/create-pull-request 1.0.7
     use: [update-packages]
     with:
       github-token: ${{ github-apps.your-orgs-bot.token }}
       branch-prefix: rwx-packages-update
       pull-request-title: Update RWX packages
       pull-request-body: "```\n${{ tasks.update-packages.values.update-output }}\n```"
+```
+
+### Enable auto-merge and request reviewers
+
+```yaml
+  - key: create-pull-request
+    call: github/create-pull-request 1.0.7
+    use: [update-packages]
+    with:
+      github-token: ${{ github-apps.your-orgs-bot.token }}
+      branch-prefix: rwx-packages-update
+      pull-request-title: Update RWX packages
+      pull-request-body: "```\n${{ tasks.update-packages.values.update-output }}\n```"
+      enable-auto-merge: true
+      reviewers: "octocat,my-org/release-reviewers"
 ```

--- a/github/create-pull-request/rwx-package.yml
+++ b/github/create-pull-request/rwx-package.yml
@@ -1,5 +1,5 @@
 name: github/create-pull-request
-version: 1.0.6
+version: 1.0.7
 description: Creates a pull request
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/create-pull-request
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -17,6 +17,12 @@ parameters:
   pull-request-body:
     description: "The body to use for the pull request"
     required: true
+  enable-auto-merge:
+    description: "Enable squash auto-merge on the pull request (requires repository auto-merge support)"
+    default: false
+  reviewers:
+    description: "Comma-separated list of reviewers to request (usernames and/or org/team slugs in `gh`'s native format)"
+    default: ""
 
 outputs:
   values-from: [create-or-update-pull-request]
@@ -72,10 +78,62 @@ tasks:
       fi
 
       pr_details=$(gh pr view "$branch" --json number,url)
-      echo "$pr_details" | jq -r '.number' > "$RWX_VALUES/pull-request-number"
-      echo "$pr_details" | jq -r '.url' > "$RWX_LINKS/View pull request"
+      pr_number=$(echo "$pr_details" | jq -r '.number')
+      pr_url=$(echo "$pr_details" | jq -r '.url')
+      echo "$pr_number" > "$RWX_VALUES/pull-request-number"
+      echo "$pr_url" > "$RWX_LINKS/View pull request"
+
+      fatal=()
+
+      # Request reviewers before enabling auto-merge so a merge-ready PR does not
+      # merge before review requests are applied. Skip auto-merge if a fatal
+      # reviewer error was already recorded.
+      if [ -n "$REVIEWERS" ]; then
+        # Self-review requests and other non-permission failures: log and continue.
+        # If a team slug is present and the org team API fails, treat as missing
+        # Members: read and record a fatal reason (PR already exists at this point).
+        if ! gh pr edit "$pr_number" --add-reviewer "$REVIEWERS"; then
+          warning="Warning: failed to request one or more reviewers (\"$REVIEWERS\"). Continuing."
+          members_read_missing=false
+          IFS=',' read -ra reviewer_list <<< "$REVIEWERS"
+          for reviewer in "${reviewer_list[@]}"; do
+            reviewer="${reviewer// /}"
+            if [[ "$reviewer" == *"/"* ]]; then
+              org="${reviewer%%/*}"
+              team="${reviewer##*/}"
+              if ! gh api "/orgs/${org}/teams/${team}" >/dev/null 2>&1; then
+                members_read_missing=true
+              fi
+              break
+            fi
+          done
+          if [ "$members_read_missing" = "true" ]; then
+            fatal+=("Requesting team reviewer(s) (\"$REVIEWERS\") failed because the GitHub App is missing the \"Members: read\" organization permission.")
+          else
+            echo "$warning"
+          fi
+        fi
+      fi
+
+      if [ "$ENABLE_AUTO_MERGE" = "true" ]; then
+        if [ "${#fatal[@]}" -gt 0 ]; then
+          fatal+=("Squash auto-merge was not attempted because of the failure(s) above.")
+        elif ! gh pr merge "$pr_number" --auto --squash; then
+          fatal+=("Failed to enable squash auto-merge. Check repository auto-merge support, merge conflicts, and that the token can merge this branch.")
+        fi
+      fi
+
+      if [ "${#fatal[@]}" -gt 0 ]; then
+        echo "Error: Pull request was created (#${pr_number}, ${pr_url}), but one or more follow-up steps failed:"
+        for msg in "${fatal[@]}"; do
+          echo "  - $msg"
+        done
+        exit 1
+      fi
     env:
       BRANCH_PREFIX: ${{ params.branch-prefix }}
       GITHUB_TOKEN: ${{ params.github-token }}
       PULL_REQUEST_TITLE: ${{ params.pull-request-title }}
       PULL_REQUEST_BODY: ${{ params.pull-request-body }}
+      ENABLE_AUTO_MERGE: ${{ params.enable-auto-merge }}
+      REVIEWERS: ${{ params.reviewers }}

--- a/github/create-pull-request/rwx-test.yml
+++ b/github/create-pull-request/rwx-test.yml
@@ -135,3 +135,93 @@ tasks:
     env:
       GITHUB_TOKEN: ${{ github-apps.rwx-cloud-bot.token }}
       PR_NUMBER: ${{ tasks.create-pr.values.pull-request-number }}
+
+  - key: code-change-auto-merge
+    after: code-change2
+    use: code
+    cache: false
+    run: |
+      # needs a unique-per-second nonce vs. other code-change tasks
+      sleep 1
+      nonce=$(date +%s)
+      echo "$nonce" | tee $RWX_VALUES/nonce
+      file="${nonce}.txt"
+      echo "$file" | tee $RWX_VALUES/file
+      touch "$file"
+
+  - key: create-pr-auto-merge
+    after: close-pr
+    call: ${{ init.package-digest }}
+    use: code-change-auto-merge
+    with:
+      github-token: ${{ github-apps.rwx-cloud-bot.token }}
+      branch-prefix: ${{ run.id }}-am
+      pull-request-title: "auto-merge test ${{ tasks.code-change-auto-merge.values.nonce }}"
+      pull-request-body: "auto-merge test ${{ tasks.code-change-auto-merge.values.nonce }}"
+      enable-auto-merge: true
+
+  - key: assert--auto-merge
+    after: create-pr-auto-merge
+    use: gh-cli
+    run: |
+      pr_details=$(gh --repo rwx-cloud/mint-update-leaves-testing pr view "$PR_NUMBER" --json autoMergeRequest)
+      echo "$pr_details"
+
+      auto_merge_enabled=$(echo "$pr_details" | jq -r '.autoMergeRequest != null')
+      if [ "$auto_merge_enabled" != "true" ]; then
+        >&2 echo "Auto-merge is not enabled on PR #${PR_NUMBER}"
+        exit 1
+      fi
+
+      merge_method=$(echo "$pr_details" | jq -r '.autoMergeRequest.mergeMethod')
+      if [ "$merge_method" != "SQUASH" ]; then
+        >&2 echo "Expected SQUASH merge method, got \"$merge_method\""
+        exit 1
+      fi
+
+      gh --repo rwx-cloud/mint-update-leaves-testing pr close "$PR_NUMBER" --delete-branch
+    env:
+      GITHUB_TOKEN: ${{ github-apps.rwx-cloud-bot.token }}
+      PR_NUMBER: ${{ tasks.create-pr-auto-merge.values.pull-request-number }}
+
+  - key: code-change-reviewers
+    after: code-change-auto-merge
+    use: code
+    cache: false
+    run: |
+      # needs a unique-per-second nonce vs. other code-change tasks
+      sleep 1
+      nonce=$(date +%s)
+      echo "$nonce" | tee $RWX_VALUES/nonce
+      file="${nonce}.txt"
+      echo "$file" | tee $RWX_VALUES/file
+      touch "$file"
+
+  - key: create-pr-reviewers
+    after: assert--auto-merge
+    call: ${{ init.package-digest }}
+    use: code-change-reviewers
+    with:
+      github-token: ${{ github-apps.rwx-cloud-bot.token }}
+      branch-prefix: ${{ run.id }}-rv
+      pull-request-title: "reviewer test ${{ tasks.code-change-reviewers.values.nonce }}"
+      pull-request-body: "reviewer test ${{ tasks.code-change-reviewers.values.nonce }}"
+      reviewers: robinaugh
+
+  - key: assert--reviewers
+    after: create-pr-reviewers
+    use: gh-cli
+    run: |
+      pr_details=$(gh --repo rwx-cloud/mint-update-leaves-testing pr view "$PR_NUMBER" --json reviewRequests)
+      echo "$pr_details"
+
+      requested=$(echo "$pr_details" | jq -r '[.reviewRequests[].login] | join(",")')
+      if ! echo "$requested" | grep -q "robinaugh"; then
+        >&2 echo "Expected robinaugh in reviewRequests on PR #${PR_NUMBER}, got \"$requested\""
+        exit 1
+      fi
+
+      gh --repo rwx-cloud/mint-update-leaves-testing pr close "$PR_NUMBER" --delete-branch
+    env:
+      GITHUB_TOKEN: ${{ github-apps.rwx-cloud-bot.token }}
+      PR_NUMBER: ${{ tasks.create-pr-reviewers.values.pull-request-number }}


### PR DESCRIPTION
### Background

[RWX-832](https://linear.app/rwx-cloud/issue/RWX-832/add-auto-merge-and-reviewer-request-support-to-githubcreate-pull)

`rwx/update-packages-github` already supported `enable-auto-merge`, but the lower-level `github/create-pull-request` package did not — meaning direct consumers couldn't opt into the same streamlined merge flow, and `rwx/update-packages-github` duplicated the logic in a follow-on task.

### Problem

`github/create-pull-request` had no way to enable auto-merge or request reviewers after creating a PR.

### Solution

- **`enable-auto-merge`** (boolean, default `false`): after create/update, runs `gh pr merge "$pr_number" --auto --squash`. Failures are logged but don't fail the task.
- **`reviewers`** (string, default `""`): comma-separated usernames and/or `org/team` slugs in `gh`'s native format. After create/update, runs `gh pr edit "$pr_number" --add-reviewer`. Failures (self-review, missing permission, invalid user) are logged but don't fail the task. If a team slug is present and the teams API returns 403, the warning specifically calls out the missing `Members: read` org permission.
- Bumps `github/create-pull-request` **1.0.6 → 1.0.7**.
- Adds `create-pr-auto-merge` + `assert--auto-merge` tests (verifies `autoMergeRequest.mergeMethod == SQUASH` via `gh pr view --json autoMergeRequest`).
- Adds `create-pr-reviewers` + `assert--reviewers` tests (verifies `robinaugh` appears in `gh pr view --json reviewRequests`).
- Updates README with both parameters, examples, and the `Members: read` permission note.
- Adds `octocat` to the cspell wordlist.

Updating `rwx/update-packages-github` to delegate auto-merge to the inner package is tracked in [RWX-840](https://linear.app/rwx-cloud/issue/RWX-840) and will follow once 1.0.7 is published.

#### Further confirmation needed

- [x] Reviewer test uses `robinaugh` as the requested reviewer — confirm this is an acceptable test account (it will receive a review request notification on each CI run, though the PR is closed immediately after).
- [x] Merge method is hard-coded to `--squash` (not exposed as a parameter), consistent with how `rwx/update-packages-github` handled it previously. Confirm this is the right call for the lower-level package.