### PR TITLE
Delegate auto-merge to github/create-pull-request in rwx/update-packages-github

### DIFF
--- a/rwx/update-packages-github/README.md
+++ b/rwx/update-packages-github/README.md
@@ -20,7 +20,7 @@ To update minor versions (recommended):
 ```yaml
 tasks:
   - key: update-rwx-packages
-    call: rwx/update-packages-github 2.0.2
+    call: rwx/update-packages-github 2.0.3
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
@@ -32,7 +32,7 @@ Customize the label:
 ```yaml
 tasks:
   - key: update-rwx-packages
-    call: rwx/update-packages-github 2.0.2
+    call: rwx/update-packages-github 2.0.3
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
@@ -51,7 +51,7 @@ Requires repository auto-merge support.
 ```yaml
 tasks:
   - key: update-rwx-packages
-    call: rwx/update-packages-github 2.0.2
+    call: rwx/update-packages-github 2.0.3
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}

--- a/rwx/update-packages-github/rwx-package.yml
+++ b/rwx/update-packages-github/rwx-package.yml
@@ -34,13 +34,13 @@ parameters:
 
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.1
+    call: rwx/install-cli 4.0.4
 
   - key: gh-cli
-    call: github/install-cli 1.0.8
+    call: github/install-cli 1.0.10
 
   - key: code
-    call: git/clone 2.0.0
+    call: git/clone 2.0.7
     with:
       repository: ${{ params.repository }}
       ref: ${{ params.ref }}

--- a/rwx/update-packages-github/rwx-package.yml
+++ b/rwx/update-packages-github/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/update-packages-github
-version: 2.0.2
+version: 2.0.3
 description: Update RWX packages for GitHub repositories
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/update-packages-github
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -67,7 +67,7 @@ tasks:
       RWX_FILE: ${{ params.rwx-file}}
 
   - key: create-or-update-pr
-    call: github/create-pull-request 1.0.3
+    call: github/create-pull-request 1.0.7
     use: update-packages
     with:
       github-token: ${{ params.github-token }}
@@ -79,6 +79,7 @@ tasks:
         ```
         ${{ tasks.update-packages.values.update-output }}
         ```
+      enable-auto-merge: ${{ params.enable-auto-merge }}
 
   - key: pull-request-options
     use: [gh-cli, code]
@@ -89,11 +90,7 @@ tasks:
         gh label create "$GITHUB_LABEL" --color "$GITHUB_LABEL_COLOR" || true
         gh pr edit "$GITHUB_PR_NUMBER" --add-label "$GITHUB_LABEL"
       fi
-      if [ "$ENABLE_AUTO_MERGE" = "true" ] && [ -n "$GITHUB_PR_NUMBER" ]; then
-        gh pr merge "$GITHUB_PR_NUMBER" --auto --squash || true
-      fi
     env:
-      ENABLE_AUTO_MERGE: ${{ params.enable-auto-merge }}
       GITHUB_TOKEN: ${{ params.github-token }}
       GITHUB_LABEL: ${{ params.label }}
       GITHUB_LABEL_COLOR: ${{ params.label-color }}


### PR DESCRIPTION
### Background

- [RWX-840](https://linear.app/rwx-cloud/issue/RWX-840/update-rwxupdate-packages-github-to-delegate-auto-merge-to)
- Follows up on #387, which published `github/create-pull-request 1.0.7` with native auto-merge support.

### Problem

`rwx/update-packages-github` enabled auto-merge by shelling out to `gh pr merge --auto --squash || true` in its own `pull-request-options` task. Now that `github/create-pull-request` handles auto-merge (and surfaces failures non-silently), the outer package should delegate instead of duplicating the logic.

### Solution

- Bump `rwx/update-packages-github` to `2.0.3`.
- Call `github/create-pull-request 1.0.7` and pass `enable-auto-merge: ${{ params.enable-auto-merge }}` through.
- Remove the local `gh pr merge --auto --squash` fallback from `pull-request-options`; label logic is unchanged.
- Update README examples to `2.0.3`.
