### PR TITLE
Support ADC discovery for GCP OIDC auth

### DIFF
--- a/google-cloud/auth-oidc/README.md
+++ b/google-cloud/auth-oidc/README.md
@@ -24,7 +24,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.0
+    call: google-cloud/auth-oidc 2.0.1
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -43,7 +43,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.0
+    call: google-cloud/auth-oidc 2.0.1
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
       service-account: ${{ vaults.your-vault.secrets.SERVICE_ACCOUNT }}
@@ -63,7 +63,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.0
+    call: google-cloud/auth-oidc 2.0.1
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
       project-id: identifier-of-my-project
@@ -83,7 +83,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.0
+    call: google-cloud/auth-oidc 2.0.1
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -124,7 +124,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.0
+    call: google-cloud/auth-oidc 2.0.1
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 

--- a/google-cloud/auth-oidc/auth-login.template.txt
+++ b/google-cloud/auth-oidc/auth-login.template.txt
@@ -45,6 +45,10 @@ PROJECT_ID="%{{PROJECT_ID}}"
 credentials_dir="$(mktemp -d)"
 token_source_file="${credentials_dir}/oidc-token.txt"
 credentials_file="${credentials_dir}/credentials.json"
+gcloud_config_dir="$HOME/.config/gcloud"
+application_default_credentials_file="${gcloud_config_dir}/application_default_credentials.json"
+
+mkdir -p "$gcloud_config_dir"
 
 audience="$AUDIENCE"
 if [[ -z "$audience" ]]; then
@@ -90,6 +94,8 @@ fi
 
 echo "$credentials_content" >"$credentials_file"
 chmod 0600 "$credentials_file"
+echo "$credentials_content" >"$application_default_credentials_file"
+chmod 0600 "$application_default_credentials_file"
 
 echo "$credentials_file" >> "${RWX_ENV}/GOOGLE_APPLICATION_CREDENTIALS"
 export GOOGLE_APPLICATION_CREDENTIALS="$credentials_file"

--- a/google-cloud/auth-oidc/rwx-package.yml
+++ b/google-cloud/auth-oidc/rwx-package.yml
@@ -1,5 +1,5 @@
 name: google-cloud/auth-oidc
-version: 2.0.0
+version: 2.0.1
 description: Authenticate to Google Cloud with OIDC and Workload Identity Federation
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/auth-oidc
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues

--- a/google-cloud/auth-oidc/rwx-package.yml
+++ b/google-cloud/auth-oidc/rwx-package.yml
@@ -61,6 +61,9 @@ tasks:
       fi
       echo 'Logging out of gcloud'
       gcloud auth revoke 2>/dev/null || true
+      gcloud_config_dir="$HOME/.config/gcloud"
+      application_default_credentials_file="${gcloud_config_dir}/application_default_credentials.json"
+      rm -f "$application_default_credentials_file"
       EOF
 
       chmod +x "$BEFORE_HOOK"

--- a/google-cloud/auth-oidc/rwx-test.yml
+++ b/google-cloud/auth-oidc/rwx-test.yml
@@ -60,6 +60,22 @@ tasks:
       GCP_OIDC_TOKEN: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp }}
       SERVICE_ACCOUNT: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
 
+  - key: test--service-account--assert-application-default-credentials
+    use: test--service-account
+    run: |
+      application_default_credentials_file="$HOME/.config/gcloud/application_default_credentials.json"
+
+      if [ ! -r "$application_default_credentials_file" ]; then
+        >&2 echo "Expected application default credentials to point to a readable file"
+        exit 1
+      fi
+
+      jq -e '.type == "external_account" and .credential_source.file' "$application_default_credentials_file" >/dev/null
+      gcloud auth application-default print-access-token >/dev/null
+    env:
+      GCP_OIDC_TOKEN: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp }}
+      SERVICE_ACCOUNT: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
+
   - key: test--service-account--assert-unauthed
     use: test--service-account
     run: |


### PR DESCRIPTION
## Summary
- Add a regression test for `google-cloud/auth-oidc` that exercises Application Default Credentials from the task command process.
- Verify ADC is available through Google's well-known credentials file at `$HOME/.config/gcloud/application_default_credentials.json`.
- Write the generated external account credentials JSON to that well-known ADC file during the before hook so Terraform/Google SDK clients can discover credentials without relying on same-task env propagation.
- Remove the ADC file in the after hook while preserving the existing `GOOGLE_APPLICATION_CREDENTIALS` output for dependent tasks.

## Testing
- Observed the new ADC regression test fail before the implementation change.
- Validated YAML locally.
- Validated the generated before hook with `bash -n`.
