### PR TITLE
[rwx/install-*] Adds support for installing without sudo

### DIFF
--- a/rwx/install-abq/README.md
+++ b/rwx/install-abq/README.md
@@ -7,7 +7,7 @@ To install the ABQ CLI:
 ```yaml
 tasks:
   - key: abq
-    call: rwx/install-abq 1.1.9
+    call: rwx/install-abq 1.1.10
 ```
 
 ### ABQ Documentation

--- a/rwx/install-abq/rwx-package.yml
+++ b/rwx/install-abq/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/install-abq
-version: 1.1.9
+version: 1.1.10
 description: ABQ is a universal test runner that runs test suites in parallel. It’s the best tool for splitting test suites into parallel jobs in CI.
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-abq
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -17,7 +17,16 @@ tasks:
       curl -o "$tmp/abq" -fsSL \
         -H "Authorization: Bearer $RWX_ACCESS_TOKEN" \
         "https://cloud.rwx.com/abq/api/releases/v1/Linux/$(uname -m)/abq?install_id=${install_id}"
-      sudo install "$tmp/abq" /usr/local/bin
+      if [ "$(id -u)" -eq 0 ]; then
+        install "$tmp/abq" /usr/local/bin
+      elif command -v sudo >/dev/null 2>&1; then
+        sudo install "$tmp/abq" /usr/local/bin
+      else
+        mkdir -p "$HOME/.local/bin"
+        install "$tmp/abq" "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$RWX_ENV/PATH"
+        export PATH="$HOME/.local/bin:$PATH"
+      fi
       rm -rf $tmp
       abq --version
     cache:

--- a/rwx/install-captain/README.md
+++ b/rwx/install-captain/README.md
@@ -9,7 +9,7 @@ To install the latest version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.1.6
+    call: rwx/install-captain 1.1.7
 ```
 
 To install a specific version of the Captain CLI:
@@ -17,7 +17,7 @@ To install a specific version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.1.6
+    call: rwx/install-captain 1.1.7
     with:
       captain-version: v2.5.3
 ```

--- a/rwx/install-captain/rwx-package.yml
+++ b/rwx/install-captain/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/install-captain
-version: 1.1.6
+version: 1.1.7
 description: Captain is an open source CLI that can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more.
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-captain
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -14,7 +14,16 @@ tasks:
     run: |
       tmpdir="$(mktemp -d)"
       curl -o "$tmpdir/captain" -fsSL "https://releases.captain.build/${CAPTAIN_VERSION}/linux/$(uname -m)/captain"
-      sudo install "$tmpdir/captain" /usr/local/bin
+      if [ "$(id -u)" -eq 0 ]; then
+        install "$tmpdir/captain" /usr/local/bin
+      elif command -v sudo >/dev/null 2>&1; then
+        sudo install "$tmpdir/captain" /usr/local/bin
+      else
+        mkdir -p "$HOME/.local/bin"
+        install "$tmpdir/captain" "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$RWX_ENV/PATH"
+        export PATH="$HOME/.local/bin:$PATH"
+      fi
       rm -rf "$tmpdir"
       captain --version
     cache:

--- a/rwx/install-cli/README.md
+++ b/rwx/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the RWX CLI:
 ```yaml
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.4
+    call: rwx/install-cli 4.0.5
 ```
 
 To install a specific version of the RWX CLI:
@@ -13,7 +13,7 @@ To install a specific version of the RWX CLI:
 ```yaml
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.4
+    call: rwx/install-cli 4.0.5
     with:
       cli-version: v3.7.0
 ```

--- a/rwx/install-cli/rwx-package.yml
+++ b/rwx/install-cli/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/install-cli
-version: 4.0.4
+version: 4.0.5
 description: Install the RWX CLI
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-cli
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -14,7 +14,16 @@ tasks:
     run: |
       tmp="$(mktemp -d)"
       curl -o "$tmp/rwx" -fsSL "https://github.com/rwx-cloud/cli/releases/download/${CLI_VERSION_PARAM}/rwx-linux-$(uname -m)"
-      sudo install "$tmp/rwx" /usr/local/bin
+      if [ "$(id -u)" -eq 0 ]; then
+        install "$tmp/rwx" /usr/local/bin
+      elif command -v sudo >/dev/null 2>&1; then
+        sudo install "$tmp/rwx" /usr/local/bin
+      else
+        mkdir -p "$HOME/.local/bin"
+        install "$tmp/rwx" "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$RWX_ENV/PATH"
+        export PATH="$HOME/.local/bin:$PATH"
+      fi
       rm -rf "$tmp"
       rwx --version
     cache:


### PR DESCRIPTION
This enables installing RWX, Captain, and ABQ when the user is already root or when sudo is unavailable.