### PR TITLE
Enforce rwx-utils.sh is current and mint-utils.sh is removed

### DIFF
--- a/.rwx/package.yml
+++ b/.rwx/package.yml
@@ -37,6 +37,37 @@ tasks:
     env:
       DIRECTORY: ${{ init.directory }}
 
+  - key: check-utils
+    use: code
+    run: |
+      rc=0
+
+      while IFS= read -r utils; do
+        [[ -z "$utils" ]] && continue
+        if ! diff rwx-utils.sh "$utils"; then
+          echo ""
+          echo "ERROR: $utils is out of date with the top-level rwx-utils.sh"
+          echo "Run 'cp rwx-utils.sh $utils' and commit the result."
+          rc=1
+        fi
+      done < <(find "$DIRECTORY" -name rwx-utils.sh)
+
+      while IFS= read -r utils; do
+        [[ -z "$utils" ]] && continue
+        echo "ERROR: $utils must be removed (mint-utils.sh has been replaced by rwx-utils.sh)."
+        rc=1
+      done < <(find "$DIRECTORY" -name mint-utils.sh)
+
+      if [[ "$rc" -eq 0 ]]; then
+        echo "Utils scripts are up to date."
+      fi
+      exit "$rc"
+    filter:
+      - rwx-utils.sh
+      - ${{ init.directory }}
+    env:
+      DIRECTORY: ${{ init.directory }}
+
   - key: timestamp
     use: code
     run: |


### PR DESCRIPTION
## What

Adds a `check-utils` task to the per-package CI pipeline (`.rwx/package.yml`). Because `package.yml` is fanned out once per *modified* package from `ci.yml`, the check only runs against packages that actually changed.

When a package is modified, the task enforces:

1. **`rwx-utils.sh` must match the top-level one** — any `rwx-utils.sh` in the package is `diff`'d against the repo-root `rwx-utils.sh`; a mismatch fails with instructions to copy the latest version.
2. **`mint-utils.sh` must be removed** — any `mint-utils.sh` in the package fails the task (it has been replaced by `rwx-utils.sh`).

The check only applies when a package actually contains one of these files — packages without them pass cleanly.

## Notes

- Uses `find` so it catches both flat copies (`nodejs/install/rwx-utils.sh`) and nested ones (`rwx/base/scripts/rwx-utils.sh`).
- All 15 existing `rwx-utils.sh` copies are currently identical to the top-level. 9 packages still carry a `mint-utils.sh`, which this check will flag the next time those packages are modified.
- `rwx lint` passes with 0 problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)