### PR TITLE
[git/clone] Improve incremental clone performance by using a stable local ref for fetches

### DIFF
--- a/git/clone/README.md
+++ b/git/clone/README.md
@@ -31,7 +31,7 @@ tasks:
 
   - key: code
     use: system-packages
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: ...
 ```
@@ -41,7 +41,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -67,7 +67,7 @@ If you're using GitHub, RWX will automatically provide a token that you can use 
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -79,7 +79,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -97,7 +97,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -174,7 +174,7 @@ For most usage, it's as easy as:
 tasks:
   - key: code
 -    call: git/clone 1.9.5
-+    call: git/clone 2.0.7
++    call: git/clone 2.0.8
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}

--- a/git/clone/bin/get-latest-sha-for-ref
+++ b/git/clone/bin/get-latest-sha-for-ref
@@ -34,6 +34,10 @@ git_clone_ref_match_sha() {
   printf '%s' "$1" | awk 'NF { print $1; exit }'
 }
 
+git_clone_ref_match_ref() {
+  printf '%s' "$1" | awk 'NF { print $2; exit }'
+}
+
 git_clone_print_ambiguous_ref_error() {
   ref=$1
   matches=$2
@@ -66,11 +70,13 @@ if [ "$LS_REMOTE_LINE_COUNT" -gt 1 ]; then
 fi
 
 RESOLVED_SHA=$(git_clone_ref_match_sha "$LS_REMOTE_OUTPUT")
+RESOLVED_REF=$(git_clone_ref_match_ref "$LS_REMOTE_OUTPUT")
 if [ "$RESOLVED_SHA" = "" ]; then
   RESOLVED_SHA="${CHECKOUT_REF}"
 fi
 echo "Latest SHA for ${CHECKOUT_REF}: ${RESOLVED_SHA}"
 printf '%s' "${RESOLVED_SHA}" >> "$RWX_VALUES/sha"
+printf '%s' "${RESOLVED_REF}" >> "$RWX_VALUES/ref"
 
 mkdir -p "${CHECKOUT_PATH}"
 cd "${CHECKOUT_PATH}"

--- a/git/clone/bin/git-clone
+++ b/git/clone/bin/git-clone
@@ -21,6 +21,8 @@ esac
 printf '%s\n' "$rel_path" > "$RWX_VALUES/git-dir-path"
 cd "${CHECKOUT_PATH}"
 
+GIT_CLONE_CHECKOUT_REF=refs/rwx/git-clone/checkout
+
 if [ ! -d .git ]; then
   git init -b main
   git remote add origin "${CHECKOUT_REPOSITORY}"
@@ -33,21 +35,36 @@ fi
 # Avoid background maintenance rewriting packfiles in incremental tool-cache runs.
 git config --local maintenance.auto false
 git config --local gc.auto 0
+git config --local core.trustctime false
+
+if git rev-parse -q --verify HEAD^{commit} >/dev/null 2>&1; then
+  git update-ref refs/rwx/git-clone/previous HEAD
+fi
 
 if [ "${FETCH_FULL_DEPTH}" = "true" ]; then
-  git fetch --no-auto-gc origin "${CHECKOUT_REF}"
+  git fetch --no-auto-gc origin "+${CHECKOUT_REF}:${GIT_CLONE_CHECKOUT_REF}"
 elif [ "${PRESERVE_GIT_DIR}" = "true" ]; then
-  git fetch --no-auto-gc --depth=1 origin "${CHECKOUT_REF}"
+  git fetch --no-auto-gc --depth=1 origin "+${CHECKOUT_REF}:${GIT_CLONE_CHECKOUT_REF}"
 else
-  git fetch --no-auto-gc --depth=1 origin "${RESOLVED_SHA}"
+  git fetch --no-auto-gc --depth=1 origin "+${RESOLVED_SHA}:${GIT_CLONE_CHECKOUT_REF}"
 fi
 
-if [ "${FETCH_FULL_DEPTH}" = "true" ] || [ "${PRESERVE_GIT_DIR}" = "true" ]; then
-  git checkout "${CHECKOUT_REF}"
-  git reset --hard "${RESOLVED_SHA}"
-else
-  git checkout FETCH_HEAD
-fi
+checkout_sha=$(git rev-parse "${GIT_CLONE_CHECKOUT_REF}^{commit}")
+
+case "${RESOLVED_REF}" in
+  refs/heads/*)
+    branch_name="${RESOLVED_REF#refs/heads/}"
+    git update-ref "refs/remotes/origin/${branch_name}" "${checkout_sha}"
+    git checkout -B "${branch_name}" "${checkout_sha}"
+    git config "branch.${branch_name}.remote" origin
+    git config "branch.${branch_name}.merge" "${RESOLVED_REF}"
+    ;;
+  *)
+    git checkout --detach "${checkout_sha}"
+    ;;
+esac
+
+git update-ref "${GIT_CLONE_CHECKOUT_REF}" HEAD
 
 # Remove untracked files that may remain from incremental cache
 git clean -fd

--- a/git/clone/rwx-package.yml
+++ b/git/clone/rwx-package.yml
@@ -1,5 +1,5 @@
 name: git/clone
-version: 2.0.7
+version: 2.0.8
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/git/clone
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -226,6 +226,7 @@ tasks:
       CHECKOUT_PATH: ${{ params.path }}
       CHECKOUT_REF: ${{ params.ref }}
       RESOLVED_SHA: ${{ tasks.get-latest-sha-for-ref.values.sha }}
+      RESOLVED_REF: ${{ tasks.get-latest-sha-for-ref.values.ref }}
       CHECKOUT_REPOSITORY: ${{ params.repository }}
       META_REF: ${{ params.meta-ref }}
       LFS: ${{ params.lfs }}

--- a/git/clone/rwx-test.yml
+++ b/git/clone/rwx-test.yml
@@ -90,6 +90,7 @@ tasks:
       git fetch
       test "$(git config --local --get maintenance.auto)" = "false"
       test "$(git config --local --get gc.auto)" = "0"
+      test "$(git config --local --get core.trustctime)" = "false"
 
       GIT_EMAIL=$(git config user.email)
       GIT_USERNAME=$(git config user.name)
@@ -123,6 +124,8 @@ tasks:
       test $GIT_USERNAME = "rwx-integration[bot]"
       test $SHA = "4704503c51f6b5dd6346e219888488ed693dc54c"
       test $REF = "do-not-delete-this-branch"
+      test "$(git rev-parse refs/rwx/git-clone/checkout)" = "$SHA"
+      test "$(git rev-parse refs/remotes/origin/do-not-delete-this-branch)" = "$SHA"
     env:
       GITHUB_TOKEN: ${{ github['rwx-cloud'].token }}
 
@@ -146,6 +149,8 @@ tasks:
       REF=$(git symbolic-ref --short HEAD)
       test $SHA = "ff0a833ae95a01cf897f5c72dc4586afc968dece"
       test $REF = "branch"
+      test "$(git rev-parse refs/rwx/git-clone/checkout)" = "$SHA"
+      test "$(git rev-parse refs/remotes/origin/branch)" = "$SHA"
 
   - key: git-clone--test-preserve-git-dir-from-nested-branch
     call: ${{ init.package-digest }}
@@ -167,6 +172,8 @@ tasks:
       REF=$(git symbolic-ref --short HEAD)
       test $SHA = "ff0a833ae95a01cf897f5c72dc4586afc968dece"
       test $REF = "nested/branch"
+      test "$(git rev-parse refs/rwx/git-clone/checkout)" = "$SHA"
+      test "$(git rev-parse refs/remotes/origin/nested/branch)" = "$SHA"
 
   - key: git-clone--test-commit-sha-ref-meta
     call: ${{ init.package-digest }}
@@ -388,6 +395,7 @@ tasks:
       git fetch
       test "$(git config --local --get maintenance.auto)" = "false"
       test "$(git config --local --get gc.auto)" = "0"
+      test "$(git config --local --get core.trustctime)" = "false"
 
       GIT_EMAIL=$(git config user.email)
       GIT_USERNAME=$(git config user.name)
@@ -457,6 +465,8 @@ tasks:
       test -d .git
       ! test -f .git/shallow
       test -e file-in-repo.txt
+      test "$(git rev-parse refs/rwx/git-clone/checkout)" = "$(git rev-parse HEAD)"
+      test "$(git symbolic-ref -q HEAD || true)" = ""
 
   - key: git-clone--test-lfs-with-path
     call: ${{ init.package-digest }}


### PR DESCRIPTION
It turns out that only updating FETCH_HEAD isn't a very good idea -- it makes the git negotiation with the origin very poor, causing the origin to send back large packfiles in cases where it doesn't need to.

This change fetches into a stable internal ref, `refs/rwx/git-clone/checkout`, so future fetches can advertise what commits they already have and receive only the missing objects.