### PR TITLE
Support mise backend-prefixed tools in rwx/tool-versions

### DIFF
--- a/rwx/tool-versions/README.md
+++ b/rwx/tool-versions/README.md
@@ -28,7 +28,7 @@ tasks:
 
   - key: tool-versions
     use: code
-    call: rwx/tool-versions 1.0.7
+    call: rwx/tool-versions 1.0.8
     filter: [.tool-versions]
 
   - key: nodejs
@@ -43,5 +43,9 @@ tasks:
 ```
 
 The output value is named based on the tool name, so we have `nodejs` and `ruby` in this example.
+
+For tools that use a [mise backend](https://mise.jdx.dev/dev-tools/backends/) prefix, the
+output value is named after the final segment of the tool name. For example, `github:rwx-cloud/rwx`
+becomes `rwx` and `npm:prettier` becomes `prettier`.
 
 Remember to include the [`filter`](https://www.rwx.com/docs/mint/filtering-files) so that the task will be cached only based on the contents of the `.tool-versions` file.

--- a/rwx/tool-versions/rwx-package.yml
+++ b/rwx/tool-versions/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/tool-versions
-version: 1.0.7
+version: 1.0.8
 description: Extract tool versions from a .tool-versions file.
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/tool-versions
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -16,8 +16,10 @@ tasks:
   - key: determine-versions
     run: |
       sed -e 's/\s*#.*$//' -e '/^\s*$/d' -e 's/^\s\+//' "$TOOL_VERSIONS_FILE" | tr -s ' ' | cut -d' ' -f-2 | while IFS=' ' read -r tool version ; do
-        echo "$tool = $version"
-        printf "$version" > "${RWX_VALUES}/${tool}"
+        name="${tool##*/}"
+        name="${name##*:}"
+        echo "$tool = $version (value: $name)"
+        printf "$version" > "${RWX_VALUES}/${name}"
       done
     env:
       TOOL_VERSIONS_FILE: ${{ params.tool-versions-file }}

--- a/rwx/tool-versions/rwx-test.yml
+++ b/rwx/tool-versions/rwx-test.yml
@@ -13,6 +13,8 @@ tasks:
         jq 1.7.1 #   comment
             nodejs   22.4.1 system
         python 3.12.4
+        github:rwx-cloud/rwx v3.19.0
+        npm:prettier 3.3.3
       EOF
 
   - key: tool-versions
@@ -40,3 +42,5 @@ tasks:
       expect_tool_version jq 1.7.1 ${{ tasks.tool-versions.values.jq }}
       expect_tool_version nodejs 22.4.1 ${{ tasks.tool-versions.values.nodejs }}
       expect_tool_version python 3.12.4 ${{ tasks.tool-versions.values.python }}
+      expect_tool_version rwx v3.19.0 ${{ tasks.tool-versions.values.rwx }}
+      expect_tool_version prettier 3.3.3 ${{ tasks.tool-versions.values.prettier }}


### PR DESCRIPTION
### Problem

`rwx/tool-versions` broke on any `.tool-versions` file using a [mise backend](https://mise.jdx.dev/dev-tools/backends/) prefix, like `github:rwx-cloud/rwx`. The task writes each version to `$RWX_VALUES/<tool>`, so the `/` in the name pointed at a subdirectory that didn't exist and the write failed, exiting the task with code 1. The `:` and `/` characters also aren't valid output value keys, and RWX skips values written into subdirectories of `$RWX_VALUES` anyway.

### Problem log
```
github:rwx-cloud/rwx = v3.19.0
/bin/bash: line 3: .../RWX_VALUES/github:rwx-cloud/rwx: No such file or directory
```

### Solution

- Name the output value after the tool's final segment, dropping any backend and owner prefix: `github:rwx-cloud/rwx` becomes `rwx`, `npm:prettier` becomes `prettier`.
- Added test coverage for both forms.
- Documented the behavior in the README and bumped 1.0.7 → 1.0.8.

#### Further confirmation needed

- [x] Confirm final-segment naming is the convention we want. Two backends sharing a basename (e.g. `github:cli/cli` and `ubi:cli/cli`) would collide on the same value key.
