### PR TITLE
Support file-based OIDC tokens

### DIFF
--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -8,7 +8,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -17,10 +17,10 @@ tasks:
     use: [aws-cli, assume-role]
     run: ...
     env:
-      AWS_OIDC_TOKEN:
-        value: ${{ vaults.your-vault.oidc.your-token }}
-        cache-key: excluded
+      AWS_OIDC_TOKEN_PATH: ${{ vaults.your-vault.oidc.your-token.path }}
 ```
+
+The package accepts either the token file path in `AWS_OIDC_TOKEN_PATH` or the token contents in `AWS_OIDC_TOKEN`. Token files are refreshed during long-running tasks, so prefer `AWS_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
 
 If for some reason you need to opt-out of role assumption, your task can set specify the environment variable `AWS_SKIP_AUTH` to true.
 
@@ -30,7 +30,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -50,7 +50,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -73,7 +73,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -96,7 +96,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -119,14 +119,14 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
 
   - key: chained-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-other-role
@@ -149,14 +149,14 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
       profile-name: your-profile
 
   - key: chained-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       source-profile-name: your-profile
       region: us-east-2
@@ -210,7 +210,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -261,14 +261,14 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
 
   - key: chain-role
-    call: aws/assume-role 2.0.9
+    call: aws/assume-role 2.0.10
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-other-role

--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -20,7 +20,7 @@ tasks:
       AWS_OIDC_TOKEN_PATH: ${{ vaults.your-vault.oidc.your-token.path }}
 ```
 
-The package accepts either the token file path in `AWS_OIDC_TOKEN_PATH` or the token contents in `AWS_OIDC_TOKEN`. Token files are refreshed during long-running tasks, so prefer `AWS_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
+The package accepts either the token file path in `AWS_OIDC_TOKEN_PATH` or the token contents in `AWS_OIDC_TOKEN`. In path mode, the package configures an AWS web identity profile so the CLI and compatible SDKs reread the rotating token file when their temporary credentials expire. Prefer `AWS_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
 
 If for some reason you need to opt-out of role assumption, your task can set specify the environment variable `AWS_SKIP_AUTH` to true.
 

--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -20,7 +20,7 @@ tasks:
       AWS_OIDC_TOKEN_PATH: ${{ vaults.your-vault.oidc.your-token.path }}
 ```
 
-The package accepts either the token file path in `AWS_OIDC_TOKEN_PATH` or the token contents in `AWS_OIDC_TOKEN`. In path mode, the package configures an AWS web identity profile so the CLI and compatible SDKs reread the rotating token file when their temporary credentials expire. Prefer `AWS_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
+The package accepts either the token file path in `AWS_OIDC_TOKEN_PATH` or the token contents in `AWS_OIDC_TOKEN`, but not both. In path mode, the package configures an AWS web identity profile so the CLI and compatible SDKs reread the rotating token file when their temporary credentials expire. Prefer `AWS_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
 
 If for some reason you need to opt-out of role assumption, your task can set specify the environment variable `AWS_SKIP_AUTH` to true.
 

--- a/aws/assume-role/assume-role.template.txt
+++ b/aws/assume-role/assume-role.template.txt
@@ -12,12 +12,13 @@ EOF
 }
 
 AWS_OIDC_TOKEN="${%{{OIDC_TOKEN_ENV_VAR}}:-}"
+AWS_OIDC_TOKEN_PATH="${%{{OIDC_TOKEN_PATH_ENV_VAR}}:-}"
 AWS_SKIP_AUTH="${AWS_SKIP_AUTH:-}"
 
-if [ -z "$AWS_SKIP_AUTH" ] && [ -z "$AWS_OIDC_TOKEN" ]; then
+if [ -z "$AWS_SKIP_AUTH" ] && [ -z "$AWS_OIDC_TOKEN" ] && [ -z "$AWS_OIDC_TOKEN_PATH" ]; then
   log_error "One of the upstream dependencies from this task's \`use\` configuration is an \`aws/assume-role\` task which configures a hook to authenticate into AWS.
 
-If this task should be authenticating into AWS, set the \`AWS_OIDC_TOKEN\` environment variable.
+If this task should be authenticating into AWS, set the \`%{{OIDC_TOKEN_ENV_VAR}}\` environment variable to the token or the \`%{{OIDC_TOKEN_PATH_ENV_VAR}}\` environment variable to its file path.
 
 If this task should not be authenticating into AWS, remove the dependency from \`use\`, or set the \`AWS_SKIP_AUTH\` environment variable to true.
 
@@ -33,6 +34,19 @@ fi
 
 if ! command -v aws &> /dev/null; then
   log_error "The AWS CLI must be installed. To install it, you can use the \`aws/install-cli\` leaf."
+  exit 1
+fi
+
+if [ -n "$AWS_OIDC_TOKEN_PATH" ]; then
+  if [ ! -r "$AWS_OIDC_TOKEN_PATH" ]; then
+    log_error "The OIDC token file at \`$AWS_OIDC_TOKEN_PATH\` is not readable."
+    exit 1
+  fi
+  AWS_OIDC_TOKEN="$(<"$AWS_OIDC_TOKEN_PATH")"
+fi
+
+if [ -z "$AWS_OIDC_TOKEN" ]; then
+  log_error "The AWS OIDC token is empty."
   exit 1
 fi
 

--- a/aws/assume-role/assume-role.template.txt
+++ b/aws/assume-role/assume-role.template.txt
@@ -15,6 +15,11 @@ AWS_OIDC_TOKEN="${%{{OIDC_TOKEN_ENV_VAR}}:-}"
 AWS_OIDC_TOKEN_PATH="${%{{OIDC_TOKEN_PATH_ENV_VAR}}:-}"
 AWS_SKIP_AUTH="${AWS_SKIP_AUTH:-}"
 
+if [ -n "$AWS_OIDC_TOKEN" ] && [ -n "$AWS_OIDC_TOKEN_PATH" ]; then
+  log_error "Only one of %{{OIDC_TOKEN_ENV_VAR}} or %{{OIDC_TOKEN_PATH_ENV_VAR}} may be set."
+  exit 1
+fi
+
 if [ -z "$AWS_SKIP_AUTH" ] && [ -z "$AWS_OIDC_TOKEN" ] && [ -z "$AWS_OIDC_TOKEN_PATH" ]; then
   log_error "One of the upstream dependencies from this task's \`use\` configuration is an \`aws/assume-role\` task which configures a hook to authenticate into AWS.
 

--- a/aws/assume-role/assume-role.template.txt
+++ b/aws/assume-role/assume-role.template.txt
@@ -37,19 +37,6 @@ if ! command -v aws &> /dev/null; then
   exit 1
 fi
 
-if [ -n "$AWS_OIDC_TOKEN_PATH" ]; then
-  if [ ! -r "$AWS_OIDC_TOKEN_PATH" ]; then
-    log_error "The OIDC token file at \`$AWS_OIDC_TOKEN_PATH\` is not readable."
-    exit 1
-  fi
-  AWS_OIDC_TOKEN="$(<"$AWS_OIDC_TOKEN_PATH")"
-fi
-
-if [ -z "$AWS_OIDC_TOKEN" ]; then
-  log_error "The AWS OIDC token is empty."
-  exit 1
-fi
-
 # These variables are filled in with parameters to the leaf
 REGION="%{{REGION}}"
 ROLE_TO_ASSUME="%{{ROLE_TO_ASSUME}}"
@@ -63,6 +50,25 @@ if [[ -z "$role_session_name" ]]; then
 fi
 
 unset AWS_PROFILE || true
+
+if [ -n "$AWS_OIDC_TOKEN_PATH" ]; then
+  if [ ! -r "$AWS_OIDC_TOKEN_PATH" ]; then
+    log_error "The OIDC token file at \`$AWS_OIDC_TOKEN_PATH\` is not readable."
+    exit 1
+  fi
+
+  aws configure set region "$REGION" --profile "$PROFILE_NAME"
+  aws configure set role_arn "$ROLE_TO_ASSUME" --profile "$PROFILE_NAME"
+  aws configure set role_session_name "$role_session_name" --profile "$PROFILE_NAME"
+  aws configure set duration_seconds "$ROLE_DURATION_SECONDS" --profile "$PROFILE_NAME"
+  aws configure set web_identity_token_file "$AWS_OIDC_TOKEN_PATH" --profile "$PROFILE_NAME"
+  exit 0
+fi
+
+if [ -z "$AWS_OIDC_TOKEN" ]; then
+  log_error "The AWS OIDC token is empty."
+  exit 1
+fi
 
 sts_result=$(
   aws sts assume-role-with-web-identity \

--- a/aws/assume-role/rwx-package.yml
+++ b/aws/assume-role/rwx-package.yml
@@ -1,5 +1,5 @@
 name: aws/assume-role
-version: 2.0.9
+version: 2.0.10
 description: Assume an AWS role
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/aws/assume-role
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -23,6 +23,9 @@ parameters:
   oidc-token-env-var:
     description: "The environment variable that contains the OIDC token."
     default: "AWS_OIDC_TOKEN"
+  oidc-token-path-env-var:
+    description: "The environment variable that contains the path to the OIDC token file."
+    default: "AWS_OIDC_TOKEN_PATH"
   role-chaining:
     description: "Enable role chaining."
     default: false
@@ -47,6 +50,7 @@ tasks:
           -v ROLE_SESSION_NAME="${{ params.role-session-name }}" \
           -v PROFILE_NAME="${{ params.profile-name }}" \
           -v OIDC_TOKEN_ENV_VAR="${{ params.oidc-token-env-var }}" \
+          -v OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-var }}" \
         '{
             gsub("%{{REGION}}", REGION);
             gsub("%{{ROLE_TO_ASSUME}}", ROLE_TO_ASSUME);
@@ -54,6 +58,7 @@ tasks:
             gsub("%{{ROLE_SESSION_NAME}}", ROLE_SESSION_NAME);
             gsub("%{{PROFILE_NAME}}", PROFILE_NAME);
             gsub("%{{OIDC_TOKEN_ENV_VAR}}", OIDC_TOKEN_ENV_VAR);
+            gsub("%{{OIDC_TOKEN_PATH_ENV_VAR}}", OIDC_TOKEN_PATH_ENV_VAR);
             print
         }' "$BEFORE_HOOK_TEMPLATE" > $BEFORE_HOOK
 

--- a/aws/assume-role/rwx-test.yml
+++ b/aws/assume-role/rwx-test.yml
@@ -82,17 +82,6 @@ tasks:
     env:
       CUSTOM_AWS_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token.path }}
 
-  - key: test--mutually-exclusive-tokens--assert
-    use: [install-cli, test--defaults]
-    run: |
-      AWS_SKIP_AUTH="" \
-      AWS_OIDC_TOKEN=static \
-      AWS_OIDC_TOKEN_PATH=/tmp/dynamic \
-        bash "$RWX_HOOKS_BEFORE_TASK/aws-assume-role--assume-default.sh" || true
-      grep -R -q "Only one of AWS_OIDC_TOKEN or AWS_OIDC_TOKEN_PATH may be set" "$RWX_ERRORS"
-    env:
-      AWS_SKIP_AUTH: true
-
   - key: test--defaults--role-chain
     call: ${{ init.package-digest }}
     with:

--- a/aws/assume-role/rwx-test.yml
+++ b/aws/assume-role/rwx-test.yml
@@ -20,7 +20,9 @@ tasks:
 
   - key: test--default-token-path--assert
     use: [install-cli, test--defaults]
-    run: aws sts get-caller-identity &> /dev/null # avoid leaking account/role info
+    run: |
+      test "$(aws configure get web_identity_token_file)" = "$AWS_OIDC_TOKEN_PATH"
+      aws sts get-caller-identity &> /dev/null # avoid leaking account/role info
     env:
       AWS_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token.path }}
 
@@ -61,6 +63,7 @@ tasks:
     use: [install-cli, test--defaults, test--custom-profile]
     run:
       - aws sts get-caller-identity &> /dev/null # avoid leaking account/role info
+      - test "$(aws configure get web_identity_token_file --profile custom)" = "$AWS_OIDC_TOKEN_2_PATH"
       - aws sts get-caller-identity --profile custom &> /dev/null # avoid leaking account/role info
     env:
       AWS_OIDC_TOKEN: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}

--- a/aws/assume-role/rwx-test.yml
+++ b/aws/assume-role/rwx-test.yml
@@ -12,13 +12,13 @@ tasks:
       region: us-east-2
       role-to-assume: ${{ vaults.rwx_packages_aws_assume_role_testing.secrets.role-to-assume }}
 
-  - key: test--defaults--assert
+  - key: test--static-token--assert
     use: [install-cli, test--defaults]
     run: aws sts get-caller-identity &> /dev/null # avoid leaking account/role info
     env:
       AWS_OIDC_TOKEN: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}
 
-  - key: test--default-token-path--assert
+  - key: test--dynamic-token--assert
     use: [install-cli, test--defaults]
     run: |
       test "$(aws configure get web_identity_token_file)" = "$AWS_OIDC_TOKEN_PATH"
@@ -51,23 +51,47 @@ tasks:
     env:
       AWS_OIDC_TOKEN: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}
 
-  - key: test--custom-profile
+  - key: test--custom-static-profile
     call: ${{ init.package-digest }}
     with:
       region: us-east-2
       role-to-assume: ${{ vaults.rwx_packages_aws_assume_role_testing.secrets.role-to-assume }}
       profile-name: custom
       oidc-token-env-var: AWS_OIDC_TOKEN_2
-      oidc-token-path-env-var: AWS_OIDC_TOKEN_2_PATH
-  - key: test--multiple-profiles--assert
-    use: [install-cli, test--defaults, test--custom-profile]
+  - key: test--multiple-static-profiles--assert
+    use: [install-cli, test--defaults, test--custom-static-profile]
     run:
       - aws sts get-caller-identity &> /dev/null # avoid leaking account/role info
-      - test "$(aws configure get web_identity_token_file --profile custom)" = "$AWS_OIDC_TOKEN_2_PATH"
       - aws sts get-caller-identity --profile custom &> /dev/null # avoid leaking account/role info
     env:
       AWS_OIDC_TOKEN: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}
-      AWS_OIDC_TOKEN_2_PATH: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token.path }}
+      AWS_OIDC_TOKEN_2: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}
+
+  - key: test--custom-dynamic-profile
+    call: ${{ init.package-digest }}
+    with:
+      region: us-east-2
+      role-to-assume: ${{ vaults.rwx_packages_aws_assume_role_testing.secrets.role-to-assume }}
+      profile-name: dynamic
+      oidc-token-path-env-var: CUSTOM_AWS_OIDC_TOKEN_PATH
+  - key: test--custom-dynamic-profile--assert
+    use: [install-cli, test--custom-dynamic-profile]
+    run: |
+      test "$(aws configure get web_identity_token_file --profile dynamic)" = "$CUSTOM_AWS_OIDC_TOKEN_PATH"
+      aws sts get-caller-identity --profile dynamic &> /dev/null # avoid leaking account/role info
+    env:
+      CUSTOM_AWS_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token.path }}
+
+  - key: test--mutually-exclusive-tokens--assert
+    use: [install-cli, test--defaults]
+    run: |
+      AWS_SKIP_AUTH="" \
+      AWS_OIDC_TOKEN=static \
+      AWS_OIDC_TOKEN_PATH=/tmp/dynamic \
+        bash "$RWX_HOOKS_BEFORE_TASK/aws-assume-role--assume-default.sh" || true
+      grep -R -q "Only one of AWS_OIDC_TOKEN or AWS_OIDC_TOKEN_PATH may be set" "$RWX_ERRORS"
+    env:
+      AWS_SKIP_AUTH: true
 
   - key: test--defaults--role-chain
     call: ${{ init.package-digest }}

--- a/aws/assume-role/rwx-test.yml
+++ b/aws/assume-role/rwx-test.yml
@@ -18,6 +18,12 @@ tasks:
     env:
       AWS_OIDC_TOKEN: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}
 
+  - key: test--default-token-path--assert
+    use: [install-cli, test--defaults]
+    run: aws sts get-caller-identity &> /dev/null # avoid leaking account/role info
+    env:
+      AWS_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token.path }}
+
   - key: test--defaults--skip-auth--assert
     use: [install-cli, test--defaults]
     run: |
@@ -50,6 +56,7 @@ tasks:
       role-to-assume: ${{ vaults.rwx_packages_aws_assume_role_testing.secrets.role-to-assume }}
       profile-name: custom
       oidc-token-env-var: AWS_OIDC_TOKEN_2
+      oidc-token-path-env-var: AWS_OIDC_TOKEN_2_PATH
   - key: test--multiple-profiles--assert
     use: [install-cli, test--defaults, test--custom-profile]
     run:
@@ -57,7 +64,7 @@ tasks:
       - aws sts get-caller-identity --profile custom &> /dev/null # avoid leaking account/role info
     env:
       AWS_OIDC_TOKEN: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}
-      AWS_OIDC_TOKEN_2: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token }}
+      AWS_OIDC_TOKEN_2_PATH: ${{ vaults.rwx_packages_aws_assume_role_testing.oidc.aws_token.path }}
 
   - key: test--defaults--role-chain
     call: ${{ init.package-digest }}

--- a/azure/auth-oidc/README.md
+++ b/azure/auth-oidc/README.md
@@ -14,13 +14,15 @@ tasks:
 
   - key: azure-auth
     use: azure-cli
-    call: azure/auth-oidc 1.0.6
+    call: azure/auth-oidc 1.0.7
     with:
-      oidc-token: ${{ vaults.your-vault.oidc.your-token }}
+      oidc-token-path: ${{ vaults.your-vault.oidc.your-token.path }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
       subscription-id: ${{ vaults.your-vault.secrets.your-azure-subscription-id }}
 ```
+
+The package accepts either `oidc-token-path` or `oidc-token`. Token files are refreshed during long-running tasks, so prefer `oidc-token-path` when it is available.
 
 To authenticate without a subscription (when managing tenant-level resources):
 
@@ -31,7 +33,7 @@ tasks:
 
   - key: azure-auth
     use: azure-cli
-    call: azure/auth-oidc 1.0.6
+    call: azure/auth-oidc 1.0.7
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}

--- a/azure/auth-oidc/README.md
+++ b/azure/auth-oidc/README.md
@@ -1,9 +1,8 @@
 # azure/auth-oidc
 
-This leaf authenticates the Azure CLI via OIDC. It works with Azure's [workload identity federation](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation).
-Specifically, you can authenticate as a service principal or user-assigned managed identity.
+This package configures hooks that authenticate the Azure CLI through [workload identity federation](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation). It supports service principals and user-assigned managed identities.
 
-The Azure CLI is required. Mint provides the [azure/install-cli](https://www.rwx.com/docs/packages/azure/install-cli) leaf.
+The Azure CLI must be installed in each task that uses the authentication hook. RWX provides the [azure/install-cli](https://www.rwx.com/docs/packages/azure/install-cli) package for this.
 
 To authenticate with an identity using a subscription:
 
@@ -13,18 +12,49 @@ tasks:
     call: azure/install-cli 1.0.8
 
   - key: azure-auth
-    use: azure-cli
-    call: azure/auth-oidc 1.0.7
+    call: azure/auth-oidc 2.0.0
     with:
-      oidc-token-path: ${{ vaults.your-vault.oidc.your-token.path }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
       subscription-id: ${{ vaults.your-vault.secrets.your-azure-subscription-id }}
+
+  - key: task-that-needs-azure
+    use: [azure-cli, azure-auth]
+    run: az account show
+    env:
+      AZURE_OIDC_TOKEN_PATH: ${{ vaults.your-vault.oidc.your-token.path }}
 ```
 
-The package accepts either `oidc-token-path` or `oidc-token`, but not both. Azure CLI only accepts token contents, not a token-file source. When `oidc-token-path` is used, the package reads the current token once during `az login`. Azure CLI will not pick up later rotations.
+The hook accepts either the token file path in `AZURE_OIDC_TOKEN_PATH` or the token contents in `AZURE_OIDC_TOKEN`, but not both. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize these environment variable names.
 
-To authenticate without a subscription (when managing tenant-level resources):
+Azure CLI only accepts token contents, not a token-file source. In path mode, the hook reads the current token immediately before each task calls `az login`. Azure CLI will not pick up later rotations while that task is still running.
+
+To authenticate without a subscription when managing tenant-level resources:
+
+```yaml
+tasks:
+  - key: azure-cli
+    call: azure/install-cli 1.0.8
+
+  - key: azure-auth
+    call: azure/auth-oidc 2.0.0
+    with:
+      client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
+      tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
+      allow-no-subscription: true
+
+  - key: task-that-needs-azure
+    use: [azure-cli, azure-auth]
+    run: az account show
+    env:
+      AZURE_OIDC_TOKEN: ${{ vaults.your-vault.oidc.your-token }}
+```
+
+Set `AZURE_SKIP_AUTH` to skip both login and logout for a task that depends on the hook but does not need Azure authentication.
+
+## Upgrading from v1
+
+Version 1 accepted the OIDC token as a package parameter and authenticated in the package task:
 
 ```yaml
 tasks:
@@ -38,5 +68,24 @@ tasks:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
-      allow-no-subscription: true
+```
+
+Version 2 generates hooks instead. Remove the OIDC token parameter and pass the token or token-file path to every task that uses the hook:
+
+```yaml
+tasks:
+  - key: azure-cli
+    call: azure/install-cli 1.0.8
+
+  - key: azure-auth
+    call: azure/auth-oidc 2.0.0
+    with:
+      client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
+      tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
+
+  - key: task-that-needs-azure
+    use: [azure-cli, azure-auth]
+    run: az account show
+    env:
+      AZURE_OIDC_TOKEN_PATH: ${{ vaults.your-vault.oidc.your-token.path }}
 ```

--- a/azure/auth-oidc/README.md
+++ b/azure/auth-oidc/README.md
@@ -14,13 +14,15 @@ tasks:
 
   - key: azure-auth
     use: azure-cli
-    call: azure/auth-oidc 1.0.6
+    call: azure/auth-oidc 1.0.7
     with:
-      oidc-token: ${{ vaults.your-vault.oidc.your-token }}
+      oidc-token-path: ${{ vaults.your-vault.oidc.your-token.path }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
       subscription-id: ${{ vaults.your-vault.secrets.your-azure-subscription-id }}
 ```
+
+The package accepts either `oidc-token-path` or `oidc-token`. Azure CLI only accepts token contents, not a token-file source. When `oidc-token-path` is used, the package reads the current token once during `az login`. Azure CLI will not pick up later rotations.
 
 To authenticate without a subscription (when managing tenant-level resources):
 
@@ -31,7 +33,7 @@ tasks:
 
   - key: azure-auth
     use: azure-cli
-    call: azure/auth-oidc 1.0.6
+    call: azure/auth-oidc 1.0.7
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}

--- a/azure/auth-oidc/README.md
+++ b/azure/auth-oidc/README.md
@@ -14,15 +14,13 @@ tasks:
 
   - key: azure-auth
     use: azure-cli
-    call: azure/auth-oidc 1.0.7
+    call: azure/auth-oidc 1.0.6
     with:
-      oidc-token-path: ${{ vaults.your-vault.oidc.your-token.path }}
+      oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
       subscription-id: ${{ vaults.your-vault.secrets.your-azure-subscription-id }}
 ```
-
-The package accepts either `oidc-token-path` or `oidc-token`. Token files are refreshed during long-running tasks, so prefer `oidc-token-path` when it is available.
 
 To authenticate without a subscription (when managing tenant-level resources):
 
@@ -33,7 +31,7 @@ tasks:
 
   - key: azure-auth
     use: azure-cli
-    call: azure/auth-oidc 1.0.7
+    call: azure/auth-oidc 1.0.6
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}

--- a/azure/auth-oidc/README.md
+++ b/azure/auth-oidc/README.md
@@ -22,7 +22,7 @@ tasks:
       subscription-id: ${{ vaults.your-vault.secrets.your-azure-subscription-id }}
 ```
 
-The package accepts either `oidc-token-path` or `oidc-token`. Azure CLI only accepts token contents, not a token-file source. When `oidc-token-path` is used, the package reads the current token once during `az login`. Azure CLI will not pick up later rotations.
+The package accepts either `oidc-token-path` or `oidc-token`, but not both. Azure CLI only accepts token contents, not a token-file source. When `oidc-token-path` is used, the package reads the current token once during `az login`. Azure CLI will not pick up later rotations.
 
 To authenticate without a subscription (when managing tenant-level resources):
 

--- a/azure/auth-oidc/auth-login.template.txt
+++ b/azure/auth-oidc/auth-login.template.txt
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+log_error() {
+  local message="$1"
+  local tmpfile
+  tmpfile=$(mktemp "$RWX_ERRORS/error-XXXX")
+  printf '%s\n' "$message" > "$tmpfile"
+}
+
+AZURE_OIDC_TOKEN="${%{{OIDC_TOKEN_ENV_VAR}}:-}"
+AZURE_OIDC_TOKEN_PATH="${%{{OIDC_TOKEN_PATH_ENV_VAR}}:-}"
+AZURE_SKIP_AUTH="${AZURE_SKIP_AUTH:-}"
+
+if [ -n "$AZURE_OIDC_TOKEN" ] && [ -n "$AZURE_OIDC_TOKEN_PATH" ]; then
+  log_error "Only one of %{{OIDC_TOKEN_ENV_VAR}} or %{{OIDC_TOKEN_PATH_ENV_VAR}} may be set."
+  exit 1
+fi
+
+if [ -n "$AZURE_SKIP_AUTH" ]; then
+  echo "AZURE_SKIP_AUTH is set, the azure/auth-oidc hook has been skipped."
+  exit 0
+fi
+
+if [ -z "$AZURE_OIDC_TOKEN" ] && [ -z "$AZURE_OIDC_TOKEN_PATH" ]; then
+  log_error "One of the upstream dependencies from this task's \`use\` configuration is an \`azure/auth-oidc\` task which configures a hook to authenticate with Azure.
+
+If this task should be authenticating with Azure, set the \`%{{OIDC_TOKEN_ENV_VAR}}\` environment variable to the token or the \`%{{OIDC_TOKEN_PATH_ENV_VAR}}\` environment variable to its file path.
+
+If this task should not be authenticating with Azure, remove the dependency from \`use\`, or set the \`AZURE_SKIP_AUTH\` environment variable to true.
+
+For more information see [https://www.rwx.com/docs/packages/azure/auth-oidc](https://www.rwx.com/docs/packages/azure/auth-oidc)"
+  exit 1
+fi
+
+if ! command -v az &> /dev/null; then
+  log_error "The Azure CLI (az) must be installed. To install it, you can use the \`azure/install-cli\` package."
+  exit 1
+fi
+
+if [ -n "$AZURE_OIDC_TOKEN_PATH" ]; then
+  if [ ! -r "$AZURE_OIDC_TOKEN_PATH" ]; then
+    log_error "The OIDC token file at \`$AZURE_OIDC_TOKEN_PATH\` is not readable."
+    exit 1
+  fi
+  AZURE_OIDC_TOKEN="$(<"$AZURE_OIDC_TOKEN_PATH")"
+fi
+
+if [ -z "$AZURE_OIDC_TOKEN" ]; then
+  log_error "The Azure OIDC token is empty."
+  exit 1
+fi
+
+CLIENT_ID="%{{CLIENT_ID}}"
+TENANT_ID="%{{TENANT_ID}}"
+SUBSCRIPTION_ID="%{{SUBSCRIPTION_ID}}"
+ALLOW_NO_SUBSCRIPTION="%{{ALLOW_NO_SUBSCRIPTION}}"
+
+if [ "$ALLOW_NO_SUBSCRIPTION" != "false" ]; then
+  az login \
+    --service-principal \
+    --username "$CLIENT_ID" \
+    --tenant "$TENANT_ID" \
+    --federated-token "$AZURE_OIDC_TOKEN" \
+    --allow-no-subscriptions
+else
+  az login \
+    --service-principal \
+    --username "$CLIENT_ID" \
+    --tenant "$TENANT_ID" \
+    --federated-token "$AZURE_OIDC_TOKEN"
+fi
+
+if [ -n "$SUBSCRIPTION_ID" ]; then
+  az account set --subscription "$SUBSCRIPTION_ID"
+fi

--- a/azure/auth-oidc/rwx-package.yml
+++ b/azure/auth-oidc/rwx-package.yml
@@ -36,6 +36,11 @@ tasks:
         printf '%s\n' "$message" > "$tmpfile"
       }
 
+      if [[ -n "$OIDC_TOKEN" && -n "$OIDC_TOKEN_PATH" ]]; then
+        log_error "Only one of \`oidc-token\` or \`oidc-token-path\` may be provided."
+        exit 1
+      fi
+
       if ! command -v az &> /dev/null; then
         log_error "The Azure CLI (az) must be installed. To install it, you can use the \`azure/install-cli\` package."
         exit 1

--- a/azure/auth-oidc/rwx-package.yml
+++ b/azure/auth-oidc/rwx-package.yml
@@ -1,5 +1,5 @@
 name: azure/auth-oidc
-version: 1.0.7
+version: 1.0.6
 description: Authenticate the Azure CLI via OIDC
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/azure/auth-oidc
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -7,10 +7,7 @@ issue_tracker_url: https://github.com/rwx-cloud/packages/issues
 parameters:
   oidc-token:
     description: "The OIDC token that will be exchanged for temporary credentials (e.g. vaults.your-vault.oidc.your-token)"
-    required: false
-  oidc-token-path:
-    description: "The path to the OIDC token file that will be exchanged for temporary credentials (e.g. vaults.your-vault.oidc.your-token.path)"
-    required: false
+    required: true
   client-id:
     description: "The client id of a service principal or a user-assigned managed identity"
     required: true
@@ -29,28 +26,10 @@ parameters:
 tasks:
   - key: auth-oidc
     run: |
-      log_error() {
-        local message="$1"
-        local tmpfile
-        tmpfile=$(mktemp "$RWX_ERRORS/error-XXXX")
-        printf '%s\n' "$message" > "$tmpfile"
-      }
-
       if ! command -v az &> /dev/null; then
-        log_error "The Azure CLI (az) must be installed. To install it, you can use the \`azure/install-cli\` package."
-        exit 1
-      fi
-
-      if [[ -n "$OIDC_TOKEN_PATH" ]]; then
-        if [[ ! -r "$OIDC_TOKEN_PATH" ]]; then
-          log_error "The OIDC token file at \`$OIDC_TOKEN_PATH\` is not readable."
-          exit 1
-        fi
-        OIDC_TOKEN="$(<"$OIDC_TOKEN_PATH")"
-      fi
-
-      if [[ -z "$OIDC_TOKEN" ]]; then
-        log_error "Either \`oidc-token\` or \`oidc-token-path\` must be provided."
+        cat << 'EOF' > $(mktemp "$RWX_ERRORS/error-XXXX")
+      The Azure CLI (az) must be installed. To install it, you can use the `azure/install-cli` leaf.
+      EOF
         exit 1
       fi
 
@@ -67,7 +46,6 @@ tasks:
       fi
     env:
       OIDC_TOKEN: ${{ params.oidc-token }}
-      OIDC_TOKEN_PATH: ${{ params.oidc-token-path }}
       CLIENT_ID: ${{ params.client-id }}
       TENANT_ID: ${{ params.tenant-id }}
       SUBSCRIPTION_ID: ${{ params.subscription-id }}

--- a/azure/auth-oidc/rwx-package.yml
+++ b/azure/auth-oidc/rwx-package.yml
@@ -1,16 +1,10 @@
 name: azure/auth-oidc
-version: 1.0.7
+version: 2.0.0
 description: Authenticate the Azure CLI via OIDC
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/azure/auth-oidc
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
 
 parameters:
-  oidc-token:
-    description: "The OIDC token that will be exchanged for temporary credentials (e.g. vaults.your-vault.oidc.your-token)"
-    required: false
-  oidc-token-path:
-    description: "The path to the OIDC token file that will be exchanged for temporary credentials (e.g. vaults.your-vault.oidc.your-token.path)"
-    required: false
   client-id:
     description: "The client id of a service principal or a user-assigned managed identity"
     required: true
@@ -22,59 +16,55 @@ parameters:
     required: false
     default: ""
   allow-no-subscription:
-    description: "Whether it is permissable to have no subscriptions associated to the client id (for use in managing tenant-level resources)"
+    description: "Whether it is permissible to have no subscriptions associated to the client id (for use in managing tenant-level resources)"
     required: false
     default: "false"
+  oidc-token-env-var:
+    description: "The environment variable that contains the OIDC token."
+    default: "AZURE_OIDC_TOKEN"
+  oidc-token-path-env-var:
+    description: "The environment variable that contains the path to the OIDC token file."
+    default: "AZURE_OIDC_TOKEN_PATH"
 
 tasks:
-  - key: auth-oidc
+  - key: produce-auth-hooks
     run: |
-      log_error() {
-        local message="$1"
-        local tmpfile
-        tmpfile=$(mktemp "$RWX_ERRORS/error-XXXX")
-        printf '%s\n' "$message" > "$tmpfile"
-      }
+      set -ueo pipefail
 
-      if [[ -n "$OIDC_TOKEN" && -n "$OIDC_TOKEN_PATH" ]]; then
-        log_error "Only one of \`oidc-token\` or \`oidc-token-path\` may be provided."
-        exit 1
+      BEFORE_HOOK_TEMPLATE="$RWX_PACKAGES_PATH/auth-login.template.txt"
+      BEFORE_HOOK="$RWX_HOOKS_BEFORE_TASK/azure-auth-oidc-login.sh"
+      AFTER_HOOK="$RWX_HOOKS_AFTER_TASK/azure-auth-oidc-login.sh"
+
+      awk \
+        -v CLIENT_ID="${{ params.client-id }}" \
+        -v TENANT_ID="${{ params.tenant-id }}" \
+        -v SUBSCRIPTION_ID="${{ params.subscription-id }}" \
+        -v ALLOW_NO_SUBSCRIPTION="${{ params.allow-no-subscription }}" \
+        -v OIDC_TOKEN_ENV_VAR="${{ params.oidc-token-env-var }}" \
+        -v OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-var }}" \
+      '{
+          gsub("%{{CLIENT_ID}}", CLIENT_ID);
+          gsub("%{{TENANT_ID}}", TENANT_ID);
+          gsub("%{{SUBSCRIPTION_ID}}", SUBSCRIPTION_ID);
+          gsub("%{{ALLOW_NO_SUBSCRIPTION}}", ALLOW_NO_SUBSCRIPTION);
+          gsub("%{{OIDC_TOKEN_ENV_VAR}}", OIDC_TOKEN_ENV_VAR);
+          gsub("%{{OIDC_TOKEN_PATH_ENV_VAR}}", OIDC_TOKEN_PATH_ENV_VAR);
+          print
+      }' "$BEFORE_HOOK_TEMPLATE" > "$BEFORE_HOOK"
+
+      bash -n "$BEFORE_HOOK" || { echo "Generated before hook script has syntax errors."; exit 1; }
+
+      cat <<'EOF' > "$AFTER_HOOK"
+      #!/bin/bash
+      set -ueo pipefail
+
+      if [ -n "${AZURE_SKIP_AUTH:-}" ]; then
+        exit 0
       fi
 
-      if ! command -v az &> /dev/null; then
-        log_error "The Azure CLI (az) must be installed. To install it, you can use the \`azure/install-cli\` package."
-        exit 1
-      fi
+      echo "Logging out of Azure"
+      az logout
+      EOF
 
-      if [[ -n "$OIDC_TOKEN_PATH" ]]; then
-        if [[ ! -r "$OIDC_TOKEN_PATH" ]]; then
-          log_error "The OIDC token file at \`$OIDC_TOKEN_PATH\` is not readable."
-          exit 1
-        fi
-        OIDC_TOKEN="$(<"$OIDC_TOKEN_PATH")"
-      fi
-
-      if [[ -z "$OIDC_TOKEN" ]]; then
-        log_error "Either \`oidc-token\` or \`oidc-token-path\` must be provided."
-        exit 1
-      fi
-
-      extra_args=()
-
-      if [[ "${ALLOW_NO_SUBSCRIPTION}" != "false" ]]; then
-        extra_args+=("--allow-no-subscriptions")
-      fi
-
-      az login --service-principal --username "${CLIENT_ID}" --tenant "${TENANT_ID}" --federated-token "${OIDC_TOKEN}" "${extra_args[@]}"
-
-      if [[ -n "${SUBSCRIPTION_ID}" ]]; then
-        az account set --subscription "${SUBSCRIPTION_ID}"
-      fi
-    env:
-      OIDC_TOKEN: ${{ params.oidc-token }}
-      OIDC_TOKEN_PATH: ${{ params.oidc-token-path }}
-      CLIENT_ID: ${{ params.client-id }}
-      TENANT_ID: ${{ params.tenant-id }}
-      SUBSCRIPTION_ID: ${{ params.subscription-id }}
-      ALLOW_NO_SUBSCRIPTION: ${{ params.allow-no-subscription }}
-    cache: false
+      chmod +x "$BEFORE_HOOK"
+      chmod +x "$AFTER_HOOK"

--- a/azure/auth-oidc/rwx-package.yml
+++ b/azure/auth-oidc/rwx-package.yml
@@ -1,5 +1,5 @@
 name: azure/auth-oidc
-version: 1.0.6
+version: 1.0.7
 description: Authenticate the Azure CLI via OIDC
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/azure/auth-oidc
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -7,7 +7,10 @@ issue_tracker_url: https://github.com/rwx-cloud/packages/issues
 parameters:
   oidc-token:
     description: "The OIDC token that will be exchanged for temporary credentials (e.g. vaults.your-vault.oidc.your-token)"
-    required: true
+    required: false
+  oidc-token-path:
+    description: "The path to the OIDC token file that will be exchanged for temporary credentials (e.g. vaults.your-vault.oidc.your-token.path)"
+    required: false
   client-id:
     description: "The client id of a service principal or a user-assigned managed identity"
     required: true
@@ -26,10 +29,28 @@ parameters:
 tasks:
   - key: auth-oidc
     run: |
+      log_error() {
+        local message="$1"
+        local tmpfile
+        tmpfile=$(mktemp "$RWX_ERRORS/error-XXXX")
+        printf '%s\n' "$message" > "$tmpfile"
+      }
+
       if ! command -v az &> /dev/null; then
-        cat << 'EOF' > $(mktemp "$RWX_ERRORS/error-XXXX")
-      The Azure CLI (az) must be installed. To install it, you can use the `azure/install-cli` leaf.
-      EOF
+        log_error "The Azure CLI (az) must be installed. To install it, you can use the \`azure/install-cli\` package."
+        exit 1
+      fi
+
+      if [[ -n "$OIDC_TOKEN_PATH" ]]; then
+        if [[ ! -r "$OIDC_TOKEN_PATH" ]]; then
+          log_error "The OIDC token file at \`$OIDC_TOKEN_PATH\` is not readable."
+          exit 1
+        fi
+        OIDC_TOKEN="$(<"$OIDC_TOKEN_PATH")"
+      fi
+
+      if [[ -z "$OIDC_TOKEN" ]]; then
+        log_error "Either \`oidc-token\` or \`oidc-token-path\` must be provided."
         exit 1
       fi
 
@@ -46,6 +67,7 @@ tasks:
       fi
     env:
       OIDC_TOKEN: ${{ params.oidc-token }}
+      OIDC_TOKEN_PATH: ${{ params.oidc-token-path }}
       CLIENT_ID: ${{ params.client-id }}
       TENANT_ID: ${{ params.tenant-id }}
       SUBSCRIPTION_ID: ${{ params.subscription-id }}

--- a/azure/auth-oidc/rwx-test.yml
+++ b/azure/auth-oidc/rwx-test.yml
@@ -7,7 +7,7 @@ tasks:
   - key: install-cli
     call: azure/install-cli 1.0.8
 
-  - key: test--authenticate
+  - key: test--authenticate-with-static-token
     use: install-cli
     call: ${{ init.package-digest }}
     with:
@@ -16,13 +16,13 @@ tasks:
       subscription-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_SUBSCRIPTION_ID }}
       tenant-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
 
-  - key: test--authenticate--assert
-    use: test--authenticate
+  - key: test--authenticate-with-static-token--assert
+    use: test--authenticate-with-static-token
     run: az account show | grep "${TENANT_ID}"
     env:
       TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
 
-  - key: test--authenticate-with-token-path
+  - key: test--authenticate-with-dynamic-token
     use: install-cli
     call: ${{ init.package-digest }}
     with:
@@ -31,8 +31,8 @@ tasks:
       subscription-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_SUBSCRIPTION_ID }}
       tenant-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
 
-  - key: test--authenticate-with-token-path--assert
-    use: test--authenticate-with-token-path
+  - key: test--authenticate-with-dynamic-token--assert
+    use: test--authenticate-with-dynamic-token
     run: az account show | grep "${TENANT_ID}"
     env:
       TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}

--- a/azure/auth-oidc/rwx-test.yml
+++ b/azure/auth-oidc/rwx-test.yml
@@ -7,32 +7,33 @@ tasks:
   - key: install-cli
     call: azure/install-cli 1.0.8
 
-  - key: test--authenticate-with-static-token
-    use: install-cli
+  - key: test--auth-hooks
     call: ${{ init.package-digest }}
     with:
-      oidc-token: ${{ vaults.mint_leaves_azure_auth_testing.oidc.azure }}
       client-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_CLIENT_ID }}
       subscription-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_SUBSCRIPTION_ID }}
       tenant-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
 
-  - key: test--authenticate-with-static-token--assert
-    use: test--authenticate-with-static-token
+  - key: test--static-token--assert
+    use: [install-cli, test--auth-hooks]
     run: az account show | grep "${TENANT_ID}"
     env:
+      AZURE_OIDC_TOKEN: ${{ vaults.mint_leaves_azure_auth_testing.oidc.azure }}
       TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
 
-  - key: test--authenticate-with-dynamic-token
-    use: install-cli
-    call: ${{ init.package-digest }}
-    with:
-      oidc-token-path: ${{ vaults.mint_leaves_azure_auth_testing.oidc.azure.path }}
-      client-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_CLIENT_ID }}
-      subscription-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_SUBSCRIPTION_ID }}
-      tenant-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
-
-  - key: test--authenticate-with-dynamic-token--assert
-    use: test--authenticate-with-dynamic-token
+  - key: test--dynamic-token--assert
+    use: [install-cli, test--auth-hooks]
     run: az account show | grep "${TENANT_ID}"
     env:
+      AZURE_OIDC_TOKEN_PATH: ${{ vaults.mint_leaves_azure_auth_testing.oidc.azure.path }}
       TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
+
+  - key: test--skip-auth--assert
+    use: [install-cli, test--auth-hooks]
+    run: |
+      if az account show &> /dev/null; then
+        >&2 echo "Expected not to be authenticated with Azure"
+        exit 1
+      fi
+    env:
+      AZURE_SKIP_AUTH: true

--- a/azure/auth-oidc/rwx-test.yml
+++ b/azure/auth-oidc/rwx-test.yml
@@ -21,18 +21,3 @@ tasks:
     run: az account show | grep "${TENANT_ID}"
     env:
       TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
-
-  - key: test--authenticate-with-token-path
-    use: install-cli
-    call: ${{ init.package-digest }}
-    with:
-      oidc-token-path: ${{ vaults.mint_leaves_azure_auth_testing.oidc.azure.path }}
-      client-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_CLIENT_ID }}
-      subscription-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_SUBSCRIPTION_ID }}
-      tenant-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
-
-  - key: test--authenticate-with-token-path--assert
-    use: test--authenticate-with-token-path
-    run: az account show | grep "${TENANT_ID}"
-    env:
-      TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}

--- a/azure/auth-oidc/rwx-test.yml
+++ b/azure/auth-oidc/rwx-test.yml
@@ -21,3 +21,18 @@ tasks:
     run: az account show | grep "${TENANT_ID}"
     env:
       TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
+
+  - key: test--authenticate-with-token-path
+    use: install-cli
+    call: ${{ init.package-digest }}
+    with:
+      oidc-token-path: ${{ vaults.mint_leaves_azure_auth_testing.oidc.azure.path }}
+      client-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_CLIENT_ID }}
+      subscription-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_SUBSCRIPTION_ID }}
+      tenant-id: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}
+
+  - key: test--authenticate-with-token-path--assert
+    use: test--authenticate-with-token-path
+    run: az account show | grep "${TENANT_ID}"
+    env:
+      TENANT_ID: ${{ vaults.mint_leaves_azure_auth_testing.secrets.AZURE_TENANT_ID }}

--- a/google-cloud/auth-oidc/README.md
+++ b/google-cloud/auth-oidc/README.md
@@ -35,7 +35,7 @@ tasks:
       GCP_OIDC_TOKEN_PATH: ${{ vaults.your-vault.oidc.gcp.path }}
 ```
 
-The package accepts either the token file path in `GCP_OIDC_TOKEN_PATH` or the token contents in `GCP_OIDC_TOKEN`. Token files are refreshed during long-running tasks and remain the credential source for Application Default Credentials, so prefer `GCP_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
+The package accepts either the token file path in `GCP_OIDC_TOKEN_PATH` or the token contents in `GCP_OIDC_TOKEN`, but not both. Token files are refreshed during long-running tasks and remain the credential source for Application Default Credentials, so prefer `GCP_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
 
 To authenticate with Google Cloud using OIDC and a Service Account:
 

--- a/google-cloud/auth-oidc/README.md
+++ b/google-cloud/auth-oidc/README.md
@@ -24,7 +24,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.1
+    call: google-cloud/auth-oidc 2.0.2
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -32,8 +32,10 @@ tasks:
     use: [install-gcloud, gcloud-auth]
     run: gcloud ...
     env:
-      GCP_OIDC_TOKEN: ${{ vaults.your-vault.oidc.gcp }}
+      GCP_OIDC_TOKEN_PATH: ${{ vaults.your-vault.oidc.gcp.path }}
 ```
+
+The package accepts either the token file path in `GCP_OIDC_TOKEN_PATH` or the token contents in `GCP_OIDC_TOKEN`. Token files are refreshed during long-running tasks and remain the credential source for Application Default Credentials, so prefer `GCP_OIDC_TOKEN_PATH` when it is available. Use the `oidc-token-path-env-var` and `oidc-token-env-var` parameters to customize the environment variable names.
 
 To authenticate with Google Cloud using OIDC and a Service Account:
 
@@ -43,7 +45,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.1
+    call: google-cloud/auth-oidc 2.0.2
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
       service-account: ${{ vaults.your-vault.secrets.SERVICE_ACCOUNT }}
@@ -63,7 +65,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.1
+    call: google-cloud/auth-oidc 2.0.2
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
       project-id: identifier-of-my-project
@@ -83,7 +85,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.1
+    call: google-cloud/auth-oidc 2.0.2
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -124,7 +126,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.1
+    call: google-cloud/auth-oidc 2.0.2
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 

--- a/google-cloud/auth-oidc/auth-login.template.txt
+++ b/google-cloud/auth-oidc/auth-login.template.txt
@@ -12,12 +12,13 @@ EOF
 }
 
 GCP_OIDC_TOKEN="${%{{OIDC_TOKEN_ENV_VAR}}:-}"
+GCP_OIDC_TOKEN_PATH="${%{{OIDC_TOKEN_PATH_ENV_VAR}}:-}"
 GCP_SKIP_AUTH="${GCP_SKIP_AUTH:-}"
 
-if [ -z "$GCP_SKIP_AUTH" ] && [ -z "$GCP_OIDC_TOKEN" ]; then
+if [ -z "$GCP_SKIP_AUTH" ] && [ -z "$GCP_OIDC_TOKEN" ] && [ -z "$GCP_OIDC_TOKEN_PATH" ]; then
   log_error "One of the upstream dependencies from this task's \`use\` configuration is a \`google-cloud/auth-oidc\` task which configures a hook to authenticate with Google Cloud.
 
-If this task should be authenticating with Google Cloud, set the \`%{{OIDC_TOKEN_ENV_VAR}}\` environment variable.
+If this task should be authenticating with Google Cloud, set the \`%{{OIDC_TOKEN_ENV_VAR}}\` environment variable to the token or the \`%{{OIDC_TOKEN_PATH_ENV_VAR}}\` environment variable to its file path.
 
 If this task should not be authenticating with Google Cloud, remove the dependency from \`use\`, or set the \`GCP_SKIP_AUTH\` environment variable to true.
 
@@ -43,7 +44,6 @@ AUDIENCE="%{{AUDIENCE}}"
 PROJECT_ID="%{{PROJECT_ID}}"
 
 credentials_dir="$(mktemp -d)"
-token_source_file="${credentials_dir}/oidc-token.txt"
 credentials_file="${credentials_dir}/credentials.json"
 gcloud_config_dir="$HOME/.config/gcloud"
 application_default_credentials_file="${gcloud_config_dir}/application_default_credentials.json"
@@ -55,10 +55,19 @@ if [[ -z "$audience" ]]; then
   audience="//iam.googleapis.com/${WORKLOAD_IDENTITY_PROVIDER}"
 fi
 
-echo
-echo "Saving OIDC token"
-echo "$GCP_OIDC_TOKEN" > "$token_source_file"
-chmod 0600 "$token_source_file"
+if [[ -n "$GCP_OIDC_TOKEN_PATH" ]]; then
+  if [[ ! -r "$GCP_OIDC_TOKEN_PATH" ]]; then
+    log_error "The OIDC token file at \`$GCP_OIDC_TOKEN_PATH\` is not readable."
+    exit 1
+  fi
+  token_source_file="$GCP_OIDC_TOKEN_PATH"
+else
+  token_source_file="${credentials_dir}/oidc-token.txt"
+  echo
+  echo "Saving OIDC token"
+  printf '%s\n' "$GCP_OIDC_TOKEN" > "$token_source_file"
+  chmod 0600 "$token_source_file"
+fi
 
 echo
 echo "Building application credentials file"

--- a/google-cloud/auth-oidc/auth-login.template.txt
+++ b/google-cloud/auth-oidc/auth-login.template.txt
@@ -15,6 +15,11 @@ GCP_OIDC_TOKEN="${%{{OIDC_TOKEN_ENV_VAR}}:-}"
 GCP_OIDC_TOKEN_PATH="${%{{OIDC_TOKEN_PATH_ENV_VAR}}:-}"
 GCP_SKIP_AUTH="${GCP_SKIP_AUTH:-}"
 
+if [ -n "$GCP_OIDC_TOKEN" ] && [ -n "$GCP_OIDC_TOKEN_PATH" ]; then
+  log_error "Only one of %{{OIDC_TOKEN_ENV_VAR}} or %{{OIDC_TOKEN_PATH_ENV_VAR}} may be set."
+  exit 1
+fi
+
 if [ -z "$GCP_SKIP_AUTH" ] && [ -z "$GCP_OIDC_TOKEN" ] && [ -z "$GCP_OIDC_TOKEN_PATH" ]; then
   log_error "One of the upstream dependencies from this task's \`use\` configuration is a \`google-cloud/auth-oidc\` task which configures a hook to authenticate with Google Cloud.
 

--- a/google-cloud/auth-oidc/rwx-package.yml
+++ b/google-cloud/auth-oidc/rwx-package.yml
@@ -1,5 +1,5 @@
 name: google-cloud/auth-oidc
-version: 2.0.1
+version: 2.0.2
 description: Authenticate to Google Cloud with OIDC and Workload Identity Federation
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/auth-oidc
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -23,6 +23,9 @@ parameters:
   oidc-token-env-var:
     description: "The environment variable that contains the OIDC token."
     default: "GCP_OIDC_TOKEN"
+  oidc-token-path-env-var:
+    description: "The environment variable that contains the path to the OIDC token file."
+    default: "GCP_OIDC_TOKEN_PATH"
 
 tasks:
   - key: produce-auth-hooks
@@ -40,6 +43,7 @@ tasks:
         -v AUDIENCE="${{ params.audience }}" \
         -v PROJECT_ID="${{ params.project-id }}" \
         -v OIDC_TOKEN_ENV_VAR="${{ params.oidc-token-env-var }}" \
+        -v OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-var }}" \
       '{
           gsub("%{{WORKLOAD_IDENTITY_PROVIDER}}", WORKLOAD_IDENTITY_PROVIDER);
           gsub("%{{SERVICE_ACCOUNT}}", SERVICE_ACCOUNT);
@@ -47,6 +51,7 @@ tasks:
           gsub("%{{AUDIENCE}}", AUDIENCE);
           gsub("%{{PROJECT_ID}}", PROJECT_ID);
           gsub("%{{OIDC_TOKEN_ENV_VAR}}", OIDC_TOKEN_ENV_VAR);
+          gsub("%{{OIDC_TOKEN_PATH_ENV_VAR}}", OIDC_TOKEN_PATH_ENV_VAR);
           print
       }' "$BEFORE_HOOK_TEMPLATE" > "$BEFORE_HOOK"
 

--- a/google-cloud/auth-oidc/rwx-test.yml
+++ b/google-cloud/auth-oidc/rwx-test.yml
@@ -103,17 +103,6 @@ tasks:
     env:
       GCP_SKIP_AUTH: "true"
 
-  - key: test--mutually-exclusive-tokens--assert
-    use: [install-cli, test--dynamic-direct-workload]
-    run: |
-      GCP_SKIP_AUTH="" \
-      GCP_OIDC_TOKEN=static \
-      GCP_OIDC_TOKEN_PATH=/tmp/dynamic \
-        bash "$RWX_HOOKS_BEFORE_TASK/gcp-auth-oidc-login.sh" || true
-      grep -R -q "Only one of GCP_OIDC_TOKEN or GCP_OIDC_TOKEN_PATH may be set" "$RWX_ERRORS"
-    env:
-      GCP_SKIP_AUTH: true
-
   - key: test--service-account-with-lifetime
     use: install-cli
     call: ${{ init.package-digest }}

--- a/google-cloud/auth-oidc/rwx-test.yml
+++ b/google-cloud/auth-oidc/rwx-test.yml
@@ -7,13 +7,13 @@ tasks:
   - key: install-cli
     call: google-cloud/install-cli 1.1.6
 
-  - key: test--direct-workload
+  - key: test--dynamic-direct-workload
     use: install-cli
     call: ${{ init.package-digest }}
     with:
       workload-identity-provider: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-  - key: test--direct-workload--assert
-    use: test--direct-workload
+  - key: test--dynamic-direct-workload--assert
+    use: test--dynamic-direct-workload
     run: |
       test "$(jq -r '.credential_source.file' "$HOME/.config/gcloud/application_default_credentials.json")" = "$GCP_OIDC_TOKEN_PATH"
       gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
@@ -22,14 +22,14 @@ tasks:
       GCP_OIDC_TOKEN_PATH: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp.path }}
       POOL_NAME: mint-sample-identity-pool
 
-  - key: test--custom-token-path-env-var
+  - key: test--custom-dynamic-token-env-var
     use: install-cli
     call: ${{ init.package-digest }}
     with:
       workload-identity-provider: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       oidc-token-path-env-var: CUSTOM_GCP_OIDC_TOKEN_PATH
-  - key: test--custom-token-path-env-var--assert
-    use: test--custom-token-path-env-var
+  - key: test--custom-dynamic-token-env-var--assert
+    use: test--custom-dynamic-token-env-var
     run: |
       gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
         grep -q "workloadIdentityPools/${POOL_NAME}/subject"
@@ -37,14 +37,14 @@ tasks:
       CUSTOM_GCP_OIDC_TOKEN_PATH: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp.path }}
       POOL_NAME: mint-sample-identity-pool
 
-  - key: test--service-account
+  - key: test--static-service-account
     use: install-cli
     call: ${{ init.package-digest }}
     with:
       workload-identity-provider: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       service-account: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
-  - key: test--service-account--assert
-    use: test--service-account
+  - key: test--static-service-account--assert
+    use: test--static-service-account
     run: |
       gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
         grep -q "$SERVICE_ACCOUNT"
@@ -67,8 +67,8 @@ tasks:
       GCP_OIDC_TOKEN: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp }}
       SERVICE_ACCOUNT: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
 
-  - key: test--service-account--assert-second-use
-    use: test--service-account
+  - key: test--static-service-account--assert-second-use
+    use: test--static-service-account
     run: |
       gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
         grep -q "$SERVICE_ACCOUNT"
@@ -76,8 +76,8 @@ tasks:
       GCP_OIDC_TOKEN: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp }}
       SERVICE_ACCOUNT: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
 
-  - key: test--service-account--assert-application-default-credentials
-    use: test--service-account
+  - key: test--static-service-account--assert-application-default-credentials
+    use: test--static-service-account
     run: |
       application_default_credentials_file="$HOME/.config/gcloud/application_default_credentials.json"
 
@@ -92,8 +92,8 @@ tasks:
       GCP_OIDC_TOKEN: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp }}
       SERVICE_ACCOUNT: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
 
-  - key: test--service-account--assert-unauthed
-    use: test--service-account
+  - key: test--static-service-account--assert-unauthed
+    use: test--static-service-account
     run: |
       active_accounts=$(gcloud auth list --filter="status:ACTIVE" --format="value(account)")
       if [ -n "$active_accounts" ]; then
@@ -102,6 +102,17 @@ tasks:
       fi
     env:
       GCP_SKIP_AUTH: "true"
+
+  - key: test--mutually-exclusive-tokens--assert
+    use: [install-cli, test--dynamic-direct-workload]
+    run: |
+      GCP_SKIP_AUTH="" \
+      GCP_OIDC_TOKEN=static \
+      GCP_OIDC_TOKEN_PATH=/tmp/dynamic \
+        bash "$RWX_HOOKS_BEFORE_TASK/gcp-auth-oidc-login.sh" || true
+      grep -R -q "Only one of GCP_OIDC_TOKEN or GCP_OIDC_TOKEN_PATH may be set" "$RWX_ERRORS"
+    env:
+      GCP_SKIP_AUTH: true
 
   - key: test--service-account-with-lifetime
     use: install-cli

--- a/google-cloud/auth-oidc/rwx-test.yml
+++ b/google-cloud/auth-oidc/rwx-test.yml
@@ -18,7 +18,22 @@ tasks:
       gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
         grep -q "workloadIdentityPools/${POOL_NAME}/subject"
     env:
-      GCP_OIDC_TOKEN: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp }}
+      GCP_OIDC_TOKEN_PATH: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp.path }}
+      POOL_NAME: mint-sample-identity-pool
+
+  - key: test--custom-token-path-env-var
+    use: install-cli
+    call: ${{ init.package-digest }}
+    with:
+      workload-identity-provider: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      oidc-token-path-env-var: CUSTOM_GCP_OIDC_TOKEN_PATH
+  - key: test--custom-token-path-env-var--assert
+    use: test--custom-token-path-env-var
+    run: |
+      gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
+        grep -q "workloadIdentityPools/${POOL_NAME}/subject"
+    env:
+      CUSTOM_GCP_OIDC_TOKEN_PATH: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp.path }}
       POOL_NAME: mint-sample-identity-pool
 
   - key: test--service-account

--- a/google-cloud/auth-oidc/rwx-test.yml
+++ b/google-cloud/auth-oidc/rwx-test.yml
@@ -15,6 +15,7 @@ tasks:
   - key: test--direct-workload--assert
     use: test--direct-workload
     run: |
+      test "$(jq -r '.credential_source.file' "$HOME/.config/gcloud/application_default_credentials.json")" = "$GCP_OIDC_TOKEN_PATH"
       gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
         grep -q "workloadIdentityPools/${POOL_NAME}/subject"
     env:

--- a/namespace/login-hook/README.md
+++ b/namespace/login-hook/README.md
@@ -2,7 +2,7 @@
 
 Configure an [RWX hook](https://www.rwx.com/docs/mint/hooks) to log in to [Namespace](https://namespace.so/).
 
-Any task that depends on this package and specifies an OIDC token file path in `NAMESPACE_OIDC_TOKEN_PATH` or token contents in `NAMESPACE_OIDC_TOKEN` will log in to Namespace for the duration of the task.
+Any task that depends on this package and specifies an OIDC token file path in `NAMESPACE_OIDC_TOKEN_PATH` or token contents in `NAMESPACE_OIDC_TOKEN` will log in to Namespace for the duration of the task. Setting both variables is an error.
 
 Namespace CLI only accepts token contents, not a token-file source. When `NAMESPACE_OIDC_TOKEN_PATH` is used, the login hook reads the current token once before the task and exchanges it for Namespace credentials. Namespace will not pick up later rotations during the same task.
 

--- a/namespace/login-hook/README.md
+++ b/namespace/login-hook/README.md
@@ -2,10 +2,12 @@
 
 Configure an [RWX hook](https://www.rwx.com/docs/mint/hooks) to log in to [Namespace](https://namespace.so/).
 
-Any task that depends on this package and specifies an oidc token in the `NAMESPACE_OIDC_TOKEN` environment variable will log in to Namespace for the duration of the task.
+Any task that depends on this package and specifies an OIDC token file path in `NAMESPACE_OIDC_TOKEN_PATH` or token contents in `NAMESPACE_OIDC_TOKEN` will log in to Namespace for the duration of the task.
+
+Namespace CLI only accepts token contents, not a token-file source. When `NAMESPACE_OIDC_TOKEN_PATH` is used, the login hook reads the current token once before the task and exchanges it for Namespace credentials. Namespace will not pick up later rotations during the same task.
 
 To avoid persisting credentials to disk, the Namespace credentials are cleaned up at the end of each task. Subsequent
-tasks that need Namespace authentication must also specify the `NAMESPACE_OIDC_TOKEN` environment variable.
+tasks that need Namespace authentication must also specify one of these environment variables.
 
 ## Example
 
@@ -15,7 +17,7 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login
-    call: namespace/login-hook 1.0.2
+    call: namespace/login-hook 1.0.3
     with:
       workspace-id: my-namespace-workspace-id
 
@@ -24,13 +26,13 @@ tasks:
     run: |
       nsc build --name foo/bar --push .
     env:
-      NAMESPACE_OIDC_TOKEN: ${{ vaults.your-rwx-vault.oidc.token-name }}
+      NAMESPACE_OIDC_TOKEN_PATH: ${{ vaults.your-rwx-vault.oidc.token-name.path }}
 ```
 
 ## Multiple Workspaces
 
 If you need to log into multiple workspaces, you can configure `namespace/login-hook` more than once.
-However, you'll need to specify `oidc-token-env-name` to prevent conflicts.
+However, you'll need to specify `oidc-token-env-name` or `oidc-token-path-env-name` to prevent conflicts.
 
 ```yaml
 tasks:
@@ -38,13 +40,13 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login-to-workspace-a
-    call: namespace/login-hook 1.0.2
+    call: namespace/login-hook 1.0.3
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_A
 
   - key: namespace-login-to-workspace-b
-    call: namespace/login-hook 1.0.2
+    call: namespace/login-hook 1.0.3
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_B

--- a/namespace/login-hook/README.md
+++ b/namespace/login-hook/README.md
@@ -2,10 +2,10 @@
 
 Configure an [RWX hook](https://www.rwx.com/docs/mint/hooks) to log in to [Namespace](https://namespace.so/).
 
-Any task that depends on this package and specifies an OIDC token file path in `NAMESPACE_OIDC_TOKEN_PATH` or token contents in `NAMESPACE_OIDC_TOKEN` will log in to Namespace for the duration of the task. Token files are refreshed during long-running tasks, so prefer `NAMESPACE_OIDC_TOKEN_PATH` when it is available.
+Any task that depends on this package and specifies an oidc token in the `NAMESPACE_OIDC_TOKEN` environment variable will log in to Namespace for the duration of the task.
 
 To avoid persisting credentials to disk, the Namespace credentials are cleaned up at the end of each task. Subsequent
-tasks that need Namespace authentication must also specify one of these environment variables.
+tasks that need Namespace authentication must also specify the `NAMESPACE_OIDC_TOKEN` environment variable.
 
 ## Example
 
@@ -15,7 +15,7 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login
-    call: namespace/login-hook 1.0.3
+    call: namespace/login-hook 1.0.2
     with:
       workspace-id: my-namespace-workspace-id
 
@@ -24,13 +24,13 @@ tasks:
     run: |
       nsc build --name foo/bar --push .
     env:
-      NAMESPACE_OIDC_TOKEN_PATH: ${{ vaults.your-rwx-vault.oidc.token-name.path }}
+      NAMESPACE_OIDC_TOKEN: ${{ vaults.your-rwx-vault.oidc.token-name }}
 ```
 
 ## Multiple Workspaces
 
 If you need to log into multiple workspaces, you can configure `namespace/login-hook` more than once.
-However, you'll need to specify `oidc-token-env-name` or `oidc-token-path-env-name` to prevent conflicts.
+However, you'll need to specify `oidc-token-env-name` to prevent conflicts.
 
 ```yaml
 tasks:
@@ -38,13 +38,13 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login-to-workspace-a
-    call: namespace/login-hook 1.0.3
+    call: namespace/login-hook 1.0.2
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_A
 
   - key: namespace-login-to-workspace-b
-    call: namespace/login-hook 1.0.3
+    call: namespace/login-hook 1.0.2
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_B

--- a/namespace/login-hook/README.md
+++ b/namespace/login-hook/README.md
@@ -2,10 +2,10 @@
 
 Configure an [RWX hook](https://www.rwx.com/docs/mint/hooks) to log in to [Namespace](https://namespace.so/).
 
-Any task that depends on this package and specifies an oidc token in the `NAMESPACE_OIDC_TOKEN` environment variable will log in to Namespace for the duration of the task.
+Any task that depends on this package and specifies an OIDC token file path in `NAMESPACE_OIDC_TOKEN_PATH` or token contents in `NAMESPACE_OIDC_TOKEN` will log in to Namespace for the duration of the task. Token files are refreshed during long-running tasks, so prefer `NAMESPACE_OIDC_TOKEN_PATH` when it is available.
 
 To avoid persisting credentials to disk, the Namespace credentials are cleaned up at the end of each task. Subsequent
-tasks that need Namespace authentication must also specify the `NAMESPACE_OIDC_TOKEN` environment variable.
+tasks that need Namespace authentication must also specify one of these environment variables.
 
 ## Example
 
@@ -15,7 +15,7 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login
-    call: namespace/login-hook 1.0.2
+    call: namespace/login-hook 1.0.3
     with:
       workspace-id: my-namespace-workspace-id
 
@@ -24,13 +24,13 @@ tasks:
     run: |
       nsc build --name foo/bar --push .
     env:
-      NAMESPACE_OIDC_TOKEN: ${{ vaults.your-rwx-vault.oidc.token-name }}
+      NAMESPACE_OIDC_TOKEN_PATH: ${{ vaults.your-rwx-vault.oidc.token-name.path }}
 ```
 
 ## Multiple Workspaces
 
 If you need to log into multiple workspaces, you can configure `namespace/login-hook` more than once.
-However, you'll need to specify `oidc-token-env-name` to prevent conflicts.
+However, you'll need to specify `oidc-token-env-name` or `oidc-token-path-env-name` to prevent conflicts.
 
 ```yaml
 tasks:
@@ -38,13 +38,13 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login-to-workspace-a
-    call: namespace/login-hook 1.0.2
+    call: namespace/login-hook 1.0.3
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_A
 
   - key: namespace-login-to-workspace-b
-    call: namespace/login-hook 1.0.2
+    call: namespace/login-hook 1.0.3
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_B

--- a/namespace/login-hook/rwx-package.yml
+++ b/namespace/login-hook/rwx-package.yml
@@ -1,5 +1,5 @@
 name: namespace/login-hook
-version: 1.0.2
+version: 1.0.3
 description: RWX hook to log in to Namespace
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/namespace/login-hook
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -11,6 +11,9 @@ parameters:
   oidc-token-env-name:
     description: "The environment variable name that contains the Namespace OIDC token."
     default: NAMESPACE_OIDC_TOKEN
+  oidc-token-path-env-name:
+    description: "The environment variable name that contains the path to the Namespace OIDC token file."
+    default: NAMESPACE_OIDC_TOKEN_PATH
 
 tasks:
   - key: produce-login-hooks
@@ -26,11 +29,27 @@ tasks:
       set -ueo pipefail
 
       _NAMESPACE_OIDC_TOKEN_ENV_VAR="${{ params.oidc-token-env-name }}"
-      declare -n _NAMESPACE_OIDC_TOKEN="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
+      _NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-name }}"
+      declare -n _NAMESPACE_OIDC_TOKEN_VALUE="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
+      declare -n _NAMESPACE_OIDC_TOKEN_PATH="$_NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR"
 
-      if [ -z "${_NAMESPACE_OIDC_TOKEN-}" ]; then
-        echo "Skipping Namespace login because \$${{ params.oidc-token-env-name }} was not provided."
+      if [ -z "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -z "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
+        echo "Skipping Namespace login because neither \$${{ params.oidc-token-env-name }} nor \$${{ params.oidc-token-path-env-name }} was provided."
         exit 0
+      fi
+
+      _NAMESPACE_OIDC_TOKEN="${_NAMESPACE_OIDC_TOKEN_VALUE-}"
+      if [ -n "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
+        if [ ! -r "$_NAMESPACE_OIDC_TOKEN_PATH" ]; then
+          log_error "The OIDC token file at \`$_NAMESPACE_OIDC_TOKEN_PATH\` is not readable."
+          exit 1
+        fi
+        _NAMESPACE_OIDC_TOKEN="$(<"$_NAMESPACE_OIDC_TOKEN_PATH")"
+      fi
+
+      if [ -z "$_NAMESPACE_OIDC_TOKEN" ]; then
+        log_error "The Namespace OIDC token is empty."
+        exit 1
       fi
 
       if ! command -v nsc &> /dev/null; then
@@ -41,7 +60,7 @@ tasks:
       echo "Logging in to Namespace with Workspace: ${{ params.workspace-id }}"
       nsc auth exchange-oidc-token \
         --tenant_id "${{ params.workspace-id }}" \
-        --token $_NAMESPACE_OIDC_TOKEN
+        --token "$_NAMESPACE_OIDC_TOKEN"
       EOF
 
       cat <<'EOF' > "$AFTER_HOOK"
@@ -49,10 +68,12 @@ tasks:
       set -ueo pipefail
 
       _NAMESPACE_OIDC_TOKEN_ENV_VAR="${{ params.oidc-token-env-name }}"
-      declare -n _NAMESPACE_OIDC_TOKEN="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
+      _NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-name }}"
+      declare -n _NAMESPACE_OIDC_TOKEN_VALUE="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
+      declare -n _NAMESPACE_OIDC_TOKEN_PATH="$_NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR"
 
-      if [ -z "${_NAMESPACE_OIDC_TOKEN-}" ]; then
-        echo "Skipping Namespace logout \$${{ params.oidc-token-env-name }} was not provided."
+      if [ -z "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -z "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
+        echo "Skipping Namespace logout because neither \$${{ params.oidc-token-env-name }} nor \$${{ params.oidc-token-path-env-name }} was provided."
         exit 0
       fi
 

--- a/namespace/login-hook/rwx-package.yml
+++ b/namespace/login-hook/rwx-package.yml
@@ -1,5 +1,5 @@
 name: namespace/login-hook
-version: 1.0.3
+version: 1.0.2
 description: RWX hook to log in to Namespace
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/namespace/login-hook
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -11,9 +11,6 @@ parameters:
   oidc-token-env-name:
     description: "The environment variable name that contains the Namespace OIDC token."
     default: NAMESPACE_OIDC_TOKEN
-  oidc-token-path-env-name:
-    description: "The environment variable name that contains the path to the Namespace OIDC token file."
-    default: NAMESPACE_OIDC_TOKEN_PATH
 
 tasks:
   - key: produce-login-hooks
@@ -29,27 +26,11 @@ tasks:
       set -ueo pipefail
 
       _NAMESPACE_OIDC_TOKEN_ENV_VAR="${{ params.oidc-token-env-name }}"
-      _NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-name }}"
-      declare -n _NAMESPACE_OIDC_TOKEN_VALUE="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
-      declare -n _NAMESPACE_OIDC_TOKEN_PATH="$_NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR"
+      declare -n _NAMESPACE_OIDC_TOKEN="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
 
-      if [ -z "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -z "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
-        echo "Skipping Namespace login because neither \$${{ params.oidc-token-env-name }} nor \$${{ params.oidc-token-path-env-name }} was provided."
+      if [ -z "${_NAMESPACE_OIDC_TOKEN-}" ]; then
+        echo "Skipping Namespace login because \$${{ params.oidc-token-env-name }} was not provided."
         exit 0
-      fi
-
-      _NAMESPACE_OIDC_TOKEN="${_NAMESPACE_OIDC_TOKEN_VALUE-}"
-      if [ -n "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
-        if [ ! -r "$_NAMESPACE_OIDC_TOKEN_PATH" ]; then
-          log_error "The OIDC token file at \`$_NAMESPACE_OIDC_TOKEN_PATH\` is not readable."
-          exit 1
-        fi
-        _NAMESPACE_OIDC_TOKEN="$(<"$_NAMESPACE_OIDC_TOKEN_PATH")"
-      fi
-
-      if [ -z "$_NAMESPACE_OIDC_TOKEN" ]; then
-        log_error "The Namespace OIDC token is empty."
-        exit 1
       fi
 
       if ! command -v nsc &> /dev/null; then
@@ -60,7 +41,7 @@ tasks:
       echo "Logging in to Namespace with Workspace: ${{ params.workspace-id }}"
       nsc auth exchange-oidc-token \
         --tenant_id "${{ params.workspace-id }}" \
-        --token "$_NAMESPACE_OIDC_TOKEN"
+        --token $_NAMESPACE_OIDC_TOKEN
       EOF
 
       cat <<'EOF' > "$AFTER_HOOK"
@@ -68,12 +49,10 @@ tasks:
       set -ueo pipefail
 
       _NAMESPACE_OIDC_TOKEN_ENV_VAR="${{ params.oidc-token-env-name }}"
-      _NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-name }}"
-      declare -n _NAMESPACE_OIDC_TOKEN_VALUE="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
-      declare -n _NAMESPACE_OIDC_TOKEN_PATH="$_NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR"
+      declare -n _NAMESPACE_OIDC_TOKEN="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
 
-      if [ -z "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -z "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
-        echo "Skipping Namespace logout because neither \$${{ params.oidc-token-env-name }} nor \$${{ params.oidc-token-path-env-name }} was provided."
+      if [ -z "${_NAMESPACE_OIDC_TOKEN-}" ]; then
+        echo "Skipping Namespace logout \$${{ params.oidc-token-env-name }} was not provided."
         exit 0
       fi
 

--- a/namespace/login-hook/rwx-package.yml
+++ b/namespace/login-hook/rwx-package.yml
@@ -33,6 +33,11 @@ tasks:
       declare -n _NAMESPACE_OIDC_TOKEN_VALUE="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
       declare -n _NAMESPACE_OIDC_TOKEN_PATH="$_NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR"
 
+      if [ -n "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -n "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
+        log_error "Only one of ${{ params.oidc-token-env-name }} or ${{ params.oidc-token-path-env-name }} may be set."
+        exit 1
+      fi
+
       if [ -z "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -z "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
         echo "Skipping Namespace login because neither \$${{ params.oidc-token-env-name }} nor \$${{ params.oidc-token-path-env-name }} was provided."
         exit 0
@@ -71,6 +76,11 @@ tasks:
       _NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR="${{ params.oidc-token-path-env-name }}"
       declare -n _NAMESPACE_OIDC_TOKEN_VALUE="$_NAMESPACE_OIDC_TOKEN_ENV_VAR"
       declare -n _NAMESPACE_OIDC_TOKEN_PATH="$_NAMESPACE_OIDC_TOKEN_PATH_ENV_VAR"
+
+      if [ -n "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -n "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
+        log_error "Only one of ${{ params.oidc-token-env-name }} or ${{ params.oidc-token-path-env-name }} may be set."
+        exit 1
+      fi
 
       if [ -z "${_NAMESPACE_OIDC_TOKEN_VALUE-}" ] && [ -z "${_NAMESPACE_OIDC_TOKEN_PATH-}" ]; then
         echo "Skipping Namespace logout because neither \$${{ params.oidc-token-env-name }} nor \$${{ params.oidc-token-path-env-name }} was provided."

--- a/namespace/login-hook/rwx-test.yml
+++ b/namespace/login-hook/rwx-test.yml
@@ -25,15 +25,3 @@ tasks:
       fi
     env:
       NAMESPACE_OIDC_TOKEN: ${{ vaults.rwx_packages_namespace_login_testing.oidc.namespace-token }}
-
-  - key: test--token-path--assert
-    use: [install-cli, test--defaults]
-    run: |
-      set +e
-      nsc workspace describe
-      if [ $? -ne 0 ]; then
-        >&2 echo "Expected to be logged into Namespace"
-        exit 1
-      fi
-    env:
-      NAMESPACE_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_namespace_login_testing.oidc.namespace-token.path }}

--- a/namespace/login-hook/rwx-test.yml
+++ b/namespace/login-hook/rwx-test.yml
@@ -37,16 +37,3 @@ tasks:
       fi
     env:
       NAMESPACE_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_namespace_login_testing.oidc.namespace-token.path }}
-
-  - key: test--mutually-exclusive-tokens--assert
-    use: [install-cli, test--defaults]
-    run: |
-      log_error() {
-        printf '%s\n' "$1" > "$RWX_ERRORS/mutually-exclusive-tokens"
-      }
-      export -f log_error
-      hook="$(find "$RWX_HOOKS_BEFORE_TASK" -name 'namespace-login--*.sh')"
-      NAMESPACE_OIDC_TOKEN=static \
-      NAMESPACE_OIDC_TOKEN_PATH=/tmp/dynamic \
-        bash "$hook" || true
-      grep -R -q "Only one of NAMESPACE_OIDC_TOKEN or NAMESPACE_OIDC_TOKEN_PATH may be set" "$RWX_ERRORS"

--- a/namespace/login-hook/rwx-test.yml
+++ b/namespace/login-hook/rwx-test.yml
@@ -41,6 +41,10 @@ tasks:
   - key: test--mutually-exclusive-tokens--assert
     use: [install-cli, test--defaults]
     run: |
+      log_error() {
+        printf '%s\n' "$1" > "$RWX_ERRORS/mutually-exclusive-tokens"
+      }
+      export -f log_error
       hook="$(find "$RWX_HOOKS_BEFORE_TASK" -name 'namespace-login--*.sh')"
       NAMESPACE_OIDC_TOKEN=static \
       NAMESPACE_OIDC_TOKEN_PATH=/tmp/dynamic \

--- a/namespace/login-hook/rwx-test.yml
+++ b/namespace/login-hook/rwx-test.yml
@@ -14,7 +14,7 @@ tasks:
     with:
       workspace-id: ${{ vaults.rwx_packages_namespace_login_testing.vars.NAMESPACE_WORKSPACE }}
 
-  - key: test--defaults--assert
+  - key: test--static-token--assert
     use: [install-cli, test--defaults]
     run: |
       set +e
@@ -26,7 +26,7 @@ tasks:
     env:
       NAMESPACE_OIDC_TOKEN: ${{ vaults.rwx_packages_namespace_login_testing.oidc.namespace-token }}
 
-  - key: test--token-path--assert
+  - key: test--dynamic-token--assert
     use: [install-cli, test--defaults]
     run: |
       set +e
@@ -37,3 +37,12 @@ tasks:
       fi
     env:
       NAMESPACE_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_namespace_login_testing.oidc.namespace-token.path }}
+
+  - key: test--mutually-exclusive-tokens--assert
+    use: [install-cli, test--defaults]
+    run: |
+      hook="$(find "$RWX_HOOKS_BEFORE_TASK" -name 'namespace-login--*.sh')"
+      NAMESPACE_OIDC_TOKEN=static \
+      NAMESPACE_OIDC_TOKEN_PATH=/tmp/dynamic \
+        bash "$hook" || true
+      grep -R -q "Only one of NAMESPACE_OIDC_TOKEN or NAMESPACE_OIDC_TOKEN_PATH may be set" "$RWX_ERRORS"

--- a/namespace/login-hook/rwx-test.yml
+++ b/namespace/login-hook/rwx-test.yml
@@ -25,3 +25,15 @@ tasks:
       fi
     env:
       NAMESPACE_OIDC_TOKEN: ${{ vaults.rwx_packages_namespace_login_testing.oidc.namespace-token }}
+
+  - key: test--token-path--assert
+    use: [install-cli, test--defaults]
+    run: |
+      set +e
+      nsc workspace describe
+      if [ $? -ne 0 ]; then
+        >&2 echo "Expected to be logged into Namespace"
+        exit 1
+      fi
+    env:
+      NAMESPACE_OIDC_TOKEN_PATH: ${{ vaults.rwx_packages_namespace_login_testing.oidc.namespace-token.path }}


### PR DESCRIPTION
## What changed

- add mutually exclusive file-based and scalar OIDC token inputs for AWS, Google Cloud, Azure, and Namespace packages
- configure AWS web identity profiles and Google external-account credentials to retain the rotating token-file path for later credential refreshes
- move Azure authentication to v2 login/logout hooks so each consuming task receives its own fresh OIDC login
- read the current token once per task for Azure CLI and Namespace CLI, whose current interfaces do not support persistent token-file credential sources
- document provider behavior, defaults, customization parameters, and the Azure/Namespace refresh limitations
- add separate package integration coverage for static and dynamic tokens

## Why

[rwx-cloud/mint#4575](https://github.com/rwx-cloud/mint/pull/4575) adds automatically refreshed OIDC token-file projections through `${{ vaults.<vault>.oidc.<token>.path }}`. Packages that consume OIDC tokens need to accept those paths while preserving compatibility with scalar token expressions.

## Impact

AWS and Google Cloud tools can renew credentials from the rotating token source during long-running tasks. Azure v2 and Namespace read the current token immediately before each consuming task, but their CLIs do not pick up later rotations within that task. Supplying both token forms is rejected before authentication.

Package versions are bumped to:

- `aws/assume-role` 2.0.10
- `google-cloud/auth-oidc` 2.0.2
- `azure/auth-oidc` 2.0.0
- `namespace/login-hook` 1.0.3

## Validation

- `rwx lint` on the changed package and test definitions
- generated hooks checked with `bash -n`
- Azure static, dynamic, skip, subscription, and logout behavior checked with a fake CLI boundary
- `rwx packages update` confirmed package dependencies are current
- `npm run spellcheck`

Vault-backed integration workflows will be verified on the PR.
