### PR TITLE
Support bootstrapping images without /etc/os-release

### DIFF
--- a/rwx/bootstrap/bootstrap.sh
+++ b/rwx/bootstrap/bootstrap.sh
@@ -15,8 +15,14 @@ docker export "$containerId" | sudo tar -x -C image -f - -p
 
 printf '%s\n' root | tee ${RWX_IMAGE}/user
 
-. image/etc/os-release
-printf '%s\n' "${ID} ${VERSION_ID}" | tee ${RWX_IMAGE}/os
+if [ -f image/etc/os-release ]; then
+  . image/etc/os-release
+  printf '%s\n' "${ID} ${VERSION_ID}" | tee ${RWX_IMAGE}/os
+else
+  imageName=$(docker container inspect "$containerId" | jq -r ".[0].Config.Image")
+  imageId=$(docker container inspect "$containerId" | jq -r ".[0].Image")
+  printf '%s\n' "${imageName} ${imageId}" | tee ${RWX_IMAGE}/os
+fi
 
 if [ -f image/bin/bash ]; then
   printf '%s\n' "/bin/bash -l -e -o pipefail" | tee ${RWX_IMAGE}/shell

--- a/rwx/bootstrap/rwx-package.yml
+++ b/rwx/bootstrap/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/bootstrap
-version: 1.3.1
+version: 1.4.0
 description: Used internally in RWX to bootstrap base images
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/bootstrap
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -21,6 +21,20 @@ tasks:
       test "$VERSION_ID" = "3.22.2"
       test "$PRETTY_NAME" = "Alpine Linux v3.22"
 
+  - key: nix
+    call: ${{ init.package-digest }}
+    with:
+      image: nixpkgs/nix-flakes:latest
+
+  - key: nix-test
+    use: nix
+    run: |
+      # nixpkgs/nix-flakes is a Nix-built image with no /etc/os-release.
+      # Bootstrapping it must still succeed (the os value falls back to the
+      # image name and ID) rather than aborting when os-release is absent.
+      test ! -f image/etc/os-release
+      test -d image/nix/store
+
   - key: redis
     call: ${{ init.package-digest }}
     with:


### PR DESCRIPTION
## Problem

Nix-built images such as `nixpkgs/nix-flakes:latest` are not based on a Linux distribution and ship no `/etc/os-release`. `bootstrap.sh` sourced it unconditionally:

```sh
. image/etc/os-release
printf '%s\n' "${ID} ${VERSION_ID}" | tee ${RWX_IMAGE}/os
```

Under `set -e`, sourcing a missing file aborts the whole script, so `rwx/bootstrap` fails on any image without `os-release`.

## Fix

Guard the sourcing. When `/etc/os-release` is present, behavior is unchanged. When it's absent, fall back to writing the image name and image ID to `os` (e.g. `nixpkgs/nix-flakes:latest sha256:...`), mirroring the existing `${name} ${version}` two-token format.

This is safe because the bootstrap-written `os` value is used by RWX only as a tool-cache namespace (cache ID `${vaultId}/${toolCacheName}/${os}/${arch}`) and as a task content-cache-key component. It is never parsed into distro/version, never used to select a package manager, ignored by the OCI-config builder, and ignored by the execution agent.

The image name + ID is deterministic (repeated runs of the same image reuse the tool cache) and unique per image (no collisions with other `os-release`-less images).

## Testing

Added `nix` / `nix-test` tasks that bootstrap `nixpkgs/nix-flakes:latest` and assert extraction succeeded with no `/etc/os-release`. Without the fix the `nix` bootstrap task itself fails, so this guards the regression.

Bumped `rwx/bootstrap` to `1.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)