### PR TITLE
mise/install: export resolved versions even with install: false

### DIFF
--- a/mise/install/README.md
+++ b/mise/install/README.md
@@ -10,7 +10,7 @@ tasks:
 
   - key: mise
     use: code
-    call: mise/install 1.0.0
+    call: mise/install 1.0.1
     filter:
       - mise.toml
 ```
@@ -24,7 +24,7 @@ This reads the mise config in the checkout root (`mise.toml`, `.mise.toml`, or
 tasks:
   - key: tools
     use: code
-    call: mise/install 1.0.0
+    call: mise/install 1.0.1
     with:
       mise-version: "2026.7.11"
 ```
@@ -34,7 +34,7 @@ tasks:
 ```yaml
 tasks:
   - key: mise
-    call: mise/install 1.0.0
+    call: mise/install 1.0.1
     with:
       install: "false"
 
@@ -49,7 +49,7 @@ tasks:
 tasks:
   - key: tools
     use: code
-    call: mise/install 1.0.0
+    call: mise/install 1.0.1
     with:
       working-directory: services/api
     filter:
@@ -58,7 +58,7 @@ tasks:
 
 ### Tool versions as output values
 
-When `mise install` runs, each resolved tool version is exported as an
+Each resolved tool version is exported as an
 [output value](https://www.rwx.com/docs/output-values) keyed by mise's tool
 name, so later tasks can reference a version without re-parsing the config:
 
@@ -66,7 +66,7 @@ name, so later tasks can reference a version without re-parsing the config:
 tasks:
   - key: mise
     use: code
-    call: mise/install 1.0.0
+    call: mise/install 1.0.1
     filter:
       - mise.toml
 
@@ -79,3 +79,23 @@ tasks:
 
 Values are the concrete resolved versions (for example `24.18.0` even if
 the config requested `24`).
+
+Versions are resolved from the config, so they're exported even with
+`install: false` — useful when you only need to know a version (e.g. to
+assert it matches a base image) without installing the tools:
+
+```yaml
+tasks:
+  - key: mise
+    use: code
+    call: mise/install 1.0.1
+    with:
+      install: "false"
+    filter:
+      - mise.toml
+
+  - key: check-node-version
+    run: test "$(node --version)" = "v$EXPECTED_NODE_VERSION"
+    env:
+      EXPECTED_NODE_VERSION: ${{ tasks.mise.values.node }}
+```

--- a/mise/install/bin/install-mise
+++ b/mise/install/bin/install-mise
@@ -23,10 +23,11 @@ EOF
 fi
 
 #
-# Ensure prerequisites (curl to fetch mise, git for some tool backends)
+# Ensure prerequisites (curl to fetch mise, git for some tool backends, jq to
+# parse mise's JSON output when exporting resolved versions as output values)
 #
 missing=""
-for cmd in curl git; do
+for cmd in curl git jq; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     missing="$missing $cmd"
   fi
@@ -34,7 +35,7 @@ done
 
 if [ -n "$missing" ]; then
   rwx_maybe_sudo apt-get update
-  rwx_maybe_sudo apt-get install -y curl ca-certificates git
+  rwx_maybe_sudo apt-get install -y curl ca-certificates git jq
   rwx_maybe_sudo apt-get clean
 fi
 
@@ -66,13 +67,17 @@ mise --version
 echo "Setting ruby.compile=false"
 mise settings set ruby.compile false
 
+# Work from the directory holding the mise config so both `mise install` and
+# version resolution read the right config.
+if [ -n "$WORKING_DIRECTORY" ]; then
+  cd "$WORKING_DIRECTORY"
+fi
+
+# Trust the config so mise will read it, whether we're installing tools or only
+# resolving their versions.
+mise trust --yes || true
+
 if [ "$RUN_MISE_INSTALL" = "true" ]; then
-  if [ -n "$WORKING_DIRECTORY" ]; then
-    cd "$WORKING_DIRECTORY"
-  fi
-
-  mise trust --yes || true
-
   echo "Installing tools from mise config"
   mise install
 
@@ -86,16 +91,20 @@ if [ "$RUN_MISE_INSTALL" = "true" ]; then
   fi
 
   mise ls
-
-  # Export each resolved tool version as an RWX output value, so later tasks can
-  # reference e.g. ${{ tasks.<key>.values.node }} without re-parsing the config.
-  # Keys are mise's tool names (e.g. `node`, not `nodejs`).
-  mise current | while read -r tool version; do
-    [ -n "$tool" ] || continue
-    printf '%s' "$version" > "$RWX_VALUES/$tool"
-  done
 else
   echo "Skipping \`mise install\` (install=false). mise is available on PATH."
 fi
+
+# Export each resolved tool version as an RWX output value, so later tasks can
+# reference e.g. ${{ tasks.<key>.values.node }} without re-parsing the config.
+# Keys are mise's tool names (e.g. `node`, not `nodejs`). `mise ls --current`
+# resolves concrete versions from the config even when the tools aren't
+# installed, so values are exported whether or not `install` ran.
+mise ls --current --json \
+  | jq -r 'to_entries[] | .key as $tool | .value[] | select(.version != null) | "\($tool) \(.version)"' \
+  | while read -r tool version; do
+      [ -n "$tool" ] || continue
+      printf '%s' "$version" > "$RWX_VALUES/$tool"
+    done
 
 echo "$path_entries" > "$RWX_ENV/PATH"

--- a/mise/install/rwx-package.yml
+++ b/mise/install/rwx-package.yml
@@ -1,5 +1,5 @@
 name: mise/install
-version: 1.0.0
+version: 1.0.1
 description: Install mise (mise-en-place) and the tools defined in its config
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/mise/install
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues

--- a/mise/install/rwx-test.yml
+++ b/mise/install/rwx-test.yml
@@ -60,3 +60,29 @@ tasks:
   - key: mise-version--assert
     use: mise-version
     run: mise --version | grep "2026.7.11"
+
+  - key: no-install
+    use: write-mise-toml
+    call: ${{ init.package-digest }}
+    with:
+      install: "false"
+
+  - key: no-install--assert-values
+    use: no-install
+    run: |
+      echo "node=$NODE_VERSION python=$PYTHON_VERSION"
+      echo "$NODE_VERSION" | grep -E '^22\.'
+      echo "$PYTHON_VERSION" | grep -E '^3\.12\.'
+    env:
+      NODE_VERSION: ${{ tasks.no-install.values.node }}
+      PYTHON_VERSION: ${{ tasks.no-install.values.python }}
+
+  - key: no-install--assert-not-installed
+    use: no-install
+    run: |
+      # install: false must not install the tools themselves
+      if command -v node >/dev/null 2>&1; then
+        echo "expected node to be absent with install: false" >&2
+        exit 1
+      fi
+      echo "tools correctly not installed"


### PR DESCRIPTION
## What

`mise/install` now exports each resolved tool version as an output value (`${{ tasks.<key>.values.<tool> }}`) **whether or not `install` runs**.

## Why

Previously the values were only exported inside the `install == true` branch, using `mise current` — which requires the tools to actually be installed. So with `install: "false"`, `tasks.<key>.values.<tool>` came back empty and any reference to it errored:

> You referenced `tasks.mise.values.node`, but `node` does not exist in the `tasks.mise.values` context.

This blocks a legitimate pattern: you only need the *version* (e.g. to assert it matches a base image like `node:24.12.0-slim`) without paying to install the tools via mise.

## How

- Resolve versions with `mise ls --current --json` instead of `mise current`. `mise ls --current` reports the **concrete resolved version** from the config (e.g. `24.18.0` for a requested `24`) even when the tool is not installed (`"installed": false`).
- Run the value-export unconditionally, after the install branch, so both modes get values. `install == true` behavior is unchanged (still installs + adds tools to PATH).
- Add `jq` to the prerequisites (mise's `--json` is its documented machine-readable output; `jq` is already present on `rwx/base`).
- Document the `install: false` + values pattern in the README.
- Add tests asserting `install: false` exports values **and** does not install the tools.

Patch version bump `1.0.0` → `1.0.1`.

## Verification

Ran the new logic end-to-end on RWX against `ubuntu:24.04` + `rwx/base`:

- `install: false` → `node=[22.23.1] python=[3.12.13]` exported, tools **not** installed ✓
- `install: true` → values exported and `node --version` matches the exported value ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)