### PR TITLE
rwx/bootstrap: pull and unpack images with crane

### DIFF
--- a/rwx/bootstrap/README.md
+++ b/rwx/bootstrap/README.md
@@ -4,3 +4,7 @@ This package is called internally within RWX to bootstrap base images.
 RWX calls it automatically; you do not need to use it directly.
 
 It extracts a container image which is then used as a base image for an RWX run.
+
+The image is pulled and unpacked with [crane](https://github.com/google/go-containerregistry),
+so no container runtime is started and the task does not set `docker: true`.
+The base layer this runs on must provide `crane`, `jq` and `tar`.

--- a/rwx/bootstrap/README.md
+++ b/rwx/bootstrap/README.md
@@ -4,7 +4,3 @@ This package is called internally within RWX to bootstrap base images.
 RWX calls it automatically; you do not need to use it directly.
 
 It extracts a container image which is then used as a base image for an RWX run.
-
-The image is pulled and unpacked with [crane](https://github.com/google/go-containerregistry),
-so no container runtime is started and the task does not set `docker: true`.
-The base layer this runs on must provide `crane`, `jq` and `tar`.

--- a/rwx/bootstrap/bootstrap.sh
+++ b/rwx/bootstrap/bootstrap.sh
@@ -29,14 +29,8 @@ IMAGE_CONFIG=$(mktemp)
 trap 'rm -f "${IMAGE_CONFIG}"' EXIT
 
 mkdir image
-# --delay-directory-restore holds off applying directory permissions until the
-# whole archive is extracted. Without it, images containing read-only directories
-# (Nix store paths are dr-xr-xr-x) fail with "Cannot mkdir: Permission denied"
-# once tar tries to write children into a directory it already made read-only.
-# root is unaffected either way, so this only matters when the layer runs as a
-# non-root user, but it costs nothing there: as root the result is identical.
 crane export --platform "${PLATFORM}" "${IMAGE}" - \
-  | tar -x -C image -f - -p --delay-directory-restore
+  | tar -x -C image -f - -p
 
 # The image config carries the env, entrypoint and command. Its digest is the
 # image ID that `docker container inspect` reported as `.Image`.

--- a/rwx/bootstrap/bootstrap.sh
+++ b/rwx/bootstrap/bootstrap.sh
@@ -8,10 +8,6 @@ SCRIPT_DIR=$(dirname "$0")
 cat "${SCRIPT_DIR}/rwx-package.yml" | awk 'NF == 0 { exit } { print }'
 echo ""
 
-# The image is pulled and unpacked without a container runtime, so the base layer
-# this runs on provides crane, jq and tar rather than dockerd. The docker CLI
-# cannot stand in for crane here: it is only an Engine API client, so pull,
-# create and export all require a reachable daemon.
 for tool in crane jq tar; do
   if ! command -v "$tool" > /dev/null 2>&1; then
     echo "Error: \`${tool}\` is required to bootstrap a base image but is not in PATH." >&2

--- a/rwx/bootstrap/bootstrap.sh
+++ b/rwx/bootstrap/bootstrap.sh
@@ -33,7 +33,14 @@ IMAGE_CONFIG=$(mktemp)
 trap 'rm -f "${IMAGE_CONFIG}"' EXIT
 
 mkdir image
-crane export --platform "${PLATFORM}" "${IMAGE}" - | tar -x -C image -f - -p
+# --delay-directory-restore holds off applying directory permissions until the
+# whole archive is extracted. Without it, images containing read-only directories
+# (Nix store paths are dr-xr-xr-x) fail with "Cannot mkdir: Permission denied"
+# once tar tries to write children into a directory it already made read-only.
+# root is unaffected either way, so this only matters when the layer runs as a
+# non-root user, but it costs nothing there: as root the result is identical.
+crane export --platform "${PLATFORM}" "${IMAGE}" - \
+  | tar -x -C image -f - -p --delay-directory-restore
 
 # The image config carries the env, entrypoint and command. Its digest is the
 # image ID that `docker container inspect` reported as `.Image`.

--- a/rwx/bootstrap/bootstrap.sh
+++ b/rwx/bootstrap/bootstrap.sh
@@ -8,10 +8,37 @@ SCRIPT_DIR=$(dirname "$0")
 cat "${SCRIPT_DIR}/rwx-package.yml" | awk 'NF == 0 { exit } { print }'
 echo ""
 
+# The image is pulled and unpacked without a container runtime, so the base layer
+# this runs on provides crane, jq and tar rather than dockerd. The docker CLI
+# cannot stand in for crane here: it is only an Engine API client, so pull,
+# create and export all require a reachable daemon.
+for tool in crane jq tar; do
+  if ! command -v "$tool" > /dev/null 2>&1; then
+    echo "Error: \`${tool}\` is required to bootstrap a base image but is not in PATH." >&2
+    exit 1
+  fi
+done
+
+# crane defaults to linux/amd64 wherever it runs, unlike `docker pull`, which
+# uses the daemon's native platform. Selecting explicitly keeps arm64 agents from
+# extracting an amd64 rootfs.
+case "$(uname -m)" in
+  x86_64) PLATFORM="linux/amd64" ;;
+  aarch64 | arm64) PLATFORM="linux/arm64" ;;
+  *) echo "Error: unsupported architecture $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Kept out of the workspace so it does not land in the task's output filesystem.
+IMAGE_CONFIG=$(mktemp)
+trap 'rm -f "${IMAGE_CONFIG}"' EXIT
+
 mkdir image
-docker pull ${IMAGE}
-containerId=$(docker create ${IMAGE})
-docker export "$containerId" | sudo tar -x -C image -f - -p
+crane export --platform "${PLATFORM}" "${IMAGE}" - | tar -x -C image -f - -p
+
+# The image config carries the env, entrypoint and command. Its digest is the
+# image ID that `docker container inspect` reported as `.Image`.
+crane config --platform "${PLATFORM}" "${IMAGE}" > "${IMAGE_CONFIG}"
+imageId=$(crane manifest --platform "${PLATFORM}" "${IMAGE}" | jq -r ".config.digest")
 
 printf '%s\n' root | tee ${RWX_IMAGE}/user
 
@@ -19,9 +46,7 @@ if [ -f image/etc/os-release ]; then
   . image/etc/os-release
   printf '%s\n' "${ID} ${VERSION_ID}" | tee ${RWX_IMAGE}/os
 else
-  imageName=$(docker container inspect "$containerId" | jq -r ".[0].Config.Image")
-  imageId=$(docker container inspect "$containerId" | jq -r ".[0].Image")
-  printf '%s\n' "${imageName} ${imageId}" | tee ${RWX_IMAGE}/os
+  printf '%s\n' "${IMAGE} ${imageId}" | tee ${RWX_IMAGE}/os
 fi
 
 if [ -f image/bin/bash ]; then
@@ -30,10 +55,10 @@ else
   printf '%s\n' "/bin/sh -l -e" | tee ${RWX_IMAGE}/shell
 fi
 
-${SCRIPT_DIR}/extract-env.sh "$containerId" ${RWX_ENV}
+${SCRIPT_DIR}/extract-env.sh "${IMAGE_CONFIG}" ${RWX_ENV}
 
-docker image inspect --format '{{json .Config.Entrypoint}}' "$IMAGE" | tee "$RWX_IMAGE/entrypoint.json"
-docker image inspect --format '{{json .Config.Cmd}}' "$IMAGE" | tee "$RWX_IMAGE/command.json"
+jq -c ".config.Entrypoint" "${IMAGE_CONFIG}" | tee "$RWX_IMAGE/entrypoint.json"
+jq -c ".config.Cmd" "${IMAGE_CONFIG}" | tee "$RWX_IMAGE/command.json"
 
-docker container inspect "$containerId" | jq -r ".[0].Image" | tee ${RWX_VALUES}/image-sha
-docker container inspect "$containerId" | jq -r ".[0].Config.Image" | tee ${RWX_VALUES}/image-name
+printf '%s\n' "${imageId}" | tee ${RWX_VALUES}/image-sha
+printf '%s\n' "${IMAGE}" | tee ${RWX_VALUES}/image-name

--- a/rwx/bootstrap/extract-env.sh
+++ b/rwx/bootstrap/extract-env.sh
@@ -3,8 +3,8 @@
 set -eu
 
 usage() {
-  echo "Usage: $0 <container> <output_dir>"
-  echo "Example: $0 my-running-container ./env_out"
+  echo "Usage: $0 <image_config_json> <output_dir>"
+  echo "Example: $0 ./image-config.json ./env_out"
   exit 1
 }
 
@@ -12,25 +12,25 @@ if [ "$#" -ne 2 ]; then
   usage
 fi
 
-CONTAINER=$1
+IMAGE_CONFIG=$1
 OUTDIR=$2
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Error: docker is not installed or not in PATH." >&2
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is not installed or not in PATH." >&2
   exit 2
 fi
 
-if ! docker container inspect "$CONTAINER" >/dev/null 2>&1; then
-  echo "Error: container '$CONTAINER' not found." >&2
+if [ ! -f "$IMAGE_CONFIG" ]; then
+  echo "Error: image config '$IMAGE_CONFIG' not found." >&2
   exit 2
 fi
 
-# Read env lines from the container's Config.Env (initial env at container start)
+# Read env lines from the image's Config.Env (initial env at container start)
 get_env_lines() {
-  if docker container inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER"; then
+  if jq -r '.config.Env // [] | .[]' "$IMAGE_CONFIG"; then
     return 0
   else
-    echo "Error: Failed to read env from container." >&2
+    echo "Error: Failed to read env from image config." >&2
     return 1
   fi
 }

--- a/rwx/bootstrap/rwx-package.yml
+++ b/rwx/bootstrap/rwx-package.yml
@@ -10,8 +10,6 @@ parameters:
     required: true
 
 tasks:
-  # No `docker: true`: the image is pulled and unpacked with crane, so no
-  # container runtime is started. The base layer must provide crane, jq and tar.
   - key: bootstrap
     run: $RWX_PACKAGE_PATH/bootstrap.sh
     env:

--- a/rwx/bootstrap/rwx-package.yml
+++ b/rwx/bootstrap/rwx-package.yml
@@ -1,5 +1,5 @@
 name: rwx/bootstrap
-version: 1.4.0
+version: 1.5.0
 description: Used internally in RWX to bootstrap base images
 source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/bootstrap
 issue_tracker_url: https://github.com/rwx-cloud/packages/issues
@@ -10,8 +10,9 @@ parameters:
     required: true
 
 tasks:
+  # No `docker: true`: the image is pulled and unpacked with crane, so no
+  # container runtime is started. The base layer must provide crane, jq and tar.
   - key: bootstrap
     run: $RWX_PACKAGE_PATH/bootstrap.sh
-    docker: true
     env:
       IMAGE: ${{ params.image }}

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -7,7 +7,27 @@ base:
   arch: ${{ init.base-arch }}
 
 tasks:
+  # In a real run this package executes on the minimal bootstrap base layer,
+  # which ships crane, jq and tar. The test bases do not, so install crane here
+  # to stand in for that layer; jq and tar already come from rwx/base.
+  - key: crane
+    run: |
+      case "$(uname -m)" in
+        x86_64) crane_arch=x86_64 ;;
+        aarch64 | arm64) crane_arch=arm64 ;;
+        *) echo "unsupported architecture $(uname -m)" >&2; exit 1 ;;
+      esac
+
+      curl -fsSL -o /tmp/crane.tgz \
+        "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz"
+      sudo tar -xzf /tmp/crane.tgz -C /usr/local/bin crane
+      rm /tmp/crane.tgz
+      crane version
+    env:
+      CRANE_VERSION: 0.20.6
+
   - key: alpine
+    use: crane
     call: ${{ init.package-digest }}
     with:
       image: public.ecr.aws/docker/library/alpine:3.22.2
@@ -22,6 +42,7 @@ tasks:
       test "$PRETTY_NAME" = "Alpine Linux v3.22"
 
   - key: nix
+    use: crane
     call: ${{ init.package-digest }}
     with:
       image: nixpkgs/nix-flakes:latest
@@ -36,6 +57,7 @@ tasks:
       test -d image/nix/store
 
   - key: redis
+    use: crane
     call: ${{ init.package-digest }}
     with:
       image: public.ecr.aws/docker/library/redis:8.2.2-alpine3.22

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -73,9 +73,6 @@ tasks:
       test -x image/bin/bash
       test "$RWX_SHELL" = "/bin/bash"
 
-      test "$IMAGE_NAME" = "nixpkgs/nix-flakes:latest"
-      printf '%s\n' "$IMAGE_SHA" | grep -Eq '^sha256:[0-9a-f]{64}$'
-
       # Config.Env, exported through $RWX_ENV and prepended to the task's env.
       test "$ENV" = "/etc/profile.d/nix.sh"
       test "$BASH_ENV" = "/etc/profile.d/nix.sh"
@@ -94,9 +91,6 @@ tasks:
       test "$(stat -c '%a' "$read_only")" = "555"
       test -n "$(ls -A "$read_only")"
       test "$(stat -c '%u:%g' image/etc)" = "$(stat -c '%u:%g' image)"
-    env:
-      IMAGE_NAME: ${{ tasks.nix.values.image-name }}
-      IMAGE_SHA: ${{ tasks.nix.values.image-sha }}
 
   - key: redis
     use: crane

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -24,6 +24,8 @@ tasks:
       rm /tmp/crane.tgz
       crane version
       printf '%s' "$platform" | tee $RWX_VALUES/platform
+
+      echo "root" | tee "${RWX_IMAGE}/user"
     env:
       CRANE_VERSION: 0.20.6
 

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -13,8 +13,8 @@ tasks:
   - key: crane
     run: |
       case "$(uname -m)" in
-        x86_64) crane_arch=x86_64 ;;
-        aarch64 | arm64) crane_arch=arm64 ;;
+        x86_64) crane_arch=x86_64; platform=linux/amd64 ;;
+        aarch64 | arm64) crane_arch=arm64; platform=linux/arm64 ;;
         *) echo "unsupported architecture $(uname -m)" >&2; exit 1 ;;
       esac
 
@@ -23,6 +23,7 @@ tasks:
       sudo tar -xzf /tmp/crane.tgz -C /usr/local/bin crane
       rm /tmp/crane.tgz
       crane version
+      printf '%s' "$platform" | tee $RWX_VALUES/platform
     env:
       CRANE_VERSION: 0.20.6
 
@@ -41,6 +42,25 @@ tasks:
       test "$VERSION_ID" = "3.22.2"
       test "$PRETTY_NAME" = "Alpine Linux v3.22"
 
+      test "$(id -u)" = "0"
+      test ! -e image/bin/bash
+      test "$RWX_SHELL" = "/bin/sh"
+
+      test "$IMAGE_NAME" = "public.ecr.aws/docker/library/alpine:3.22.2"
+      test "$IMAGE_SHA" = "sha256:$(crane config --platform "$PLATFORM" "$IMAGE_NAME" | sha256sum | cut -d ' ' -f 1)"
+
+      # tar -p keeps the modes recorded in the image.
+      test "$(stat -c '%a' image/etc)" = "755"
+      test "$(stat -c '%a' image/root)" = "700"
+      test "$(stat -c '%a' image/tmp)" = "1777"
+      test "$(stat -c '%a' image/var/empty)" = "555"
+
+      test "$(stat -c '%u:%g' image/etc)" = "$(stat -c '%u:%g' image)"
+    env:
+      PLATFORM: ${{ tasks.crane.values.platform }}
+      IMAGE_NAME: ${{ tasks.alpine.values.image-name }}
+      IMAGE_SHA: ${{ tasks.alpine.values.image-sha }}
+
   - key: nix
     use: crane
     call: ${{ init.package-digest }}
@@ -54,14 +74,61 @@ tasks:
       test ! -f image/etc/os-release
       test -d image/nix/store
 
+      test "$(id -u)" = "0"
+      test -x image/bin/bash
+      test "$RWX_SHELL" = "/bin/bash"
+
+      test "$IMAGE_NAME" = "nixpkgs/nix-flakes:latest"
+      printf '%s\n' "$IMAGE_SHA" | grep -Eq '^sha256:[0-9a-f]{64}$'
+
+      # Config.Env, exported through $RWX_ENV and prepended to the task's env.
+      test "$ENV" = "/etc/profile.d/nix.sh"
+      test "$BASH_ENV" = "/etc/profile.d/nix.sh"
+      test "$NIX_BUILD_SHELL" = "/bin/bash"
+      test "$PAGER" = "cat"
+      test "$USER" = "root"
+      case "$NIX_PATH" in nixpkgs=/nix/store/*) ;; *) exit 1 ;; esac
+      case "$SSL_CERT_FILE" in /nix/store/*/ca-bundle.crt) ;; *) exit 1 ;; esac
+      # This image lists PATH twice; the last entry wins, the same as docker.
+      case "$PATH" in /root/.nix-profile/bin:/usr/bin:/bin:*) ;; *) exit 1 ;; esac
+
+      # Nix store paths are dr-xr-xr-x
+      test "$(stat -c '%a' image/etc)" = "555"
+      read_only=$(find image/nix/store -mindepth 1 -maxdepth 1 -type d ! -perm -u+w -print -quit)
+      test -n "$read_only"
+      test "$(stat -c '%a' "$read_only")" = "555"
+      test -n "$(ls -A "$read_only")"
+      test "$(stat -c '%u:%g' image/etc)" = "$(stat -c '%u:%g' image)"
+    env:
+      IMAGE_NAME: ${{ tasks.nix.values.image-name }}
+      IMAGE_SHA: ${{ tasks.nix.values.image-sha }}
+
   - key: redis
     use: crane
     call: ${{ init.package-digest }}
     with:
       image: public.ecr.aws/docker/library/redis:8.2.2-alpine3.22
 
-  - key: test-env
+  - key: redis-test
     use: redis
     run: |
-      test -n "$REDIS_DOWNLOAD_URL"
-      test -n "$REDIS_DOWNLOAD_SHA"
+      test "$(id -u)" = "0"
+      test ! -e image/bin/bash
+      test "$RWX_SHELL" = "/bin/sh"
+
+      test "$IMAGE_NAME" = "public.ecr.aws/docker/library/redis:8.2.2-alpine3.22"
+      test "$IMAGE_SHA" = "sha256:$(crane config --platform "$PLATFORM" "$IMAGE_NAME" | sha256sum | cut -d ' ' -f 1)"
+
+      test "$REDIS_DOWNLOAD_URL" = "https://github.com/redis/redis/archive/refs/tags/8.2.2.tar.gz"
+      test "$REDIS_DOWNLOAD_SHA" = "e355378d7f97efd06321fff881efc452a9673cc27b3a6d0dfd2a45fbcc83349c"
+
+      # tar -p keeps the modes recorded in the image, setgid included.
+      test "$(stat -c '%a' image/home/redis)" = "2755"
+      test "$(stat -c '%a' image/data)" = "755"
+      test "$(stat -c '%a' image/var/empty)" = "555"
+
+      test "$(stat -c '%u:%g' image/etc)" = "$(stat -c '%u:%g' image)"
+    env:
+      PLATFORM: ${{ tasks.crane.values.platform }}
+      IMAGE_NAME: ${{ tasks.redis.values.image-name }}
+      IMAGE_SHA: ${{ tasks.redis.values.image-sha }}

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -51,8 +51,6 @@ tasks:
     use: nix
     run: |
       # nixpkgs/nix-flakes is a Nix-built image with no /etc/os-release.
-      # Bootstrapping it must still succeed (the os value falls back to the
-      # image name and ID) rather than aborting when os-release is absent.
       test ! -f image/etc/os-release
       test -d image/nix/store
 

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -46,9 +46,6 @@ tasks:
       test ! -e image/bin/bash
       test "$RWX_SHELL" = "/bin/sh"
 
-      test "$IMAGE_NAME" = "public.ecr.aws/docker/library/alpine:3.22.2"
-      test "$IMAGE_SHA" = "sha256:$(crane config --platform "$PLATFORM" "$IMAGE_NAME" | sha256sum | cut -d ' ' -f 1)"
-
       # tar -p keeps the modes recorded in the image.
       test "$(stat -c '%a' image/etc)" = "755"
       test "$(stat -c '%a' image/root)" = "700"
@@ -56,10 +53,6 @@ tasks:
       test "$(stat -c '%a' image/var/empty)" = "555"
 
       test "$(stat -c '%u:%g' image/etc)" = "$(stat -c '%u:%g' image)"
-    env:
-      PLATFORM: ${{ tasks.crane.values.platform }}
-      IMAGE_NAME: ${{ tasks.alpine.values.image-name }}
-      IMAGE_SHA: ${{ tasks.alpine.values.image-sha }}
 
   - key: nix
     use: crane
@@ -116,9 +109,6 @@ tasks:
       test ! -e image/bin/bash
       test "$RWX_SHELL" = "/bin/sh"
 
-      test "$IMAGE_NAME" = "public.ecr.aws/docker/library/redis:8.2.2-alpine3.22"
-      test "$IMAGE_SHA" = "sha256:$(crane config --platform "$PLATFORM" "$IMAGE_NAME" | sha256sum | cut -d ' ' -f 1)"
-
       test "$REDIS_DOWNLOAD_URL" = "https://github.com/redis/redis/archive/refs/tags/8.2.2.tar.gz"
       test "$REDIS_DOWNLOAD_SHA" = "e355378d7f97efd06321fff881efc452a9673cc27b3a6d0dfd2a45fbcc83349c"
 
@@ -128,7 +118,3 @@ tasks:
       test "$(stat -c '%a' image/var/empty)" = "555"
 
       test "$(stat -c '%u:%g' image/etc)" = "$(stat -c '%u:%g' image)"
-    env:
-      PLATFORM: ${{ tasks.crane.values.platform }}
-      IMAGE_NAME: ${{ tasks.redis.values.image-name }}
-      IMAGE_SHA: ${{ tasks.redis.values.image-sha }}


### PR DESCRIPTION
## Why

`bootstrap.sh` drove everything through the docker CLI — `pull`, `create`, `export`, `container inspect`, `image inspect`. The CLI is only an Engine API client, so every one of those needs a reachable `dockerd`. That forces `docker: true` on the task and forces the base layer it runs on to ship `dockerd` + `containerd` + `runc`.

That's the wrong shape for a layer whose only job is to extract the run's image and which never becomes part of a task filesystem. It's also a live failure: [rwx-cloud/base-images#39](https://github.com/rwx-cloud/base-images/pull/39) builds a minimal `bootstrap` layer, and `~base-image` fails on it with:

```
`dockerd` must be installed to use Docker in your task.
```

## What

`crane` does the same work daemonlessly from a single static binary:

| before | after |
|---|---|
| `docker pull` + `create` + `export` | `crane export` |
| `docker image inspect .Config.Env` | `jq .config.Env` of `crane config` |
| `docker image inspect .Config.Entrypoint` | `jq .config.Entrypoint` |
| `docker image inspect .Config.Cmd` | `jq .config.Cmd` |
| `docker container inspect .Image` | `.config.digest` of `crane manifest` |
| `docker container inspect .Config.Image` | `$IMAGE` as given |

## Verification

Ran against the previous docker-based implementation on **ubuntu:22.04, ubuntu:24.04, alpine:3.23, busybox:1.37**, on both **linux/amd64 and linux/arm64**, platforms pinned equal. `user`, `os`, `shell`, `entrypoint.json`, `command.json`, `image-sha`, `image-name` and every `RWX_ENV` file are **identical**.

The extracted rootfs differs only by artifacts `dockerd` injects into a running container, which were never part of the image:

```
.dockerenv   /dev/console   /dev/pts   /dev/shm   /etc/mtab
# plus the zeroed /etc/hosts, /etc/resolv.conf, /etc/hostname stubs a live container bind-mounts
```

Also ran the three images `rwx-test.yml` covers (alpine 3.22.2, `nixpkgs/nix-flakes:latest`, redis 8.2.2-alpine3.22) through the real package files and asserted what those tests assert — including the no-`/etc/os-release` fallback for the Nix image, which extracts with zero tar warnings.

## Implementation notes

- **`crane` defaults to `linux/amd64` wherever it runs**, whereas `docker pull` follows the daemon's native platform. `--platform` is derived from `uname -m` so arm64 agents can't silently extract an amd64 rootfs. This is the easiest thing to get wrong here.
- The image config goes to a `mktemp` file cleaned up on exit, so it doesn't land in the task's output filesystem next to `image/`.
- `extract-env.sh` took a container id, which no longer exists — it now takes the image config JSON.
- `sudo` is gone from the `tar` invocation; the bootstrap layer runs as root.
- A preflight check reports a clear error if `crane`, `jq` or `tar` is missing, rather than a bare `not found`.
- `rwx-test.yml` gains a `crane` task the bootstrap calls `use:`, standing in for what the real bootstrap layer provides. `jq` and `tar` already come from `rwx/base`.

## Depends on

1. A base layer providing crane — [rwx-cloud/base-images#39](https://github.com/rwx-cloud/base-images/pull/39).
2. Dropping `docker: true` from the generated `~base-image` task in mint. Note `resolvedUseDocker` is a hashed cache-key component, so that step is a global cache bust for `~base-image`.

**Deploy ordering matters:** this version requires a base layer with crane. It must not become the resolved version while image-based runs still select the old docker-CLI layer.