### PR TITLE
Update all packages to the V2 package format

### DIFF
--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -70,7 +70,7 @@ tasks:
       packages=$(ls */*/rwx-package.yml | cut -d/ -f1,2)
       while read -r package; do
         echo "Checking $package..."
-        version=$(grep '^version:' $package/rwx-package.yml | awk '{print $2}')
+        version=$(grep '^  version:' $package/rwx-package.yml | awk '{print $2}')
         major_version=$(echo "$version" | cut -d. -f1)
         previous_major_version=$(("$major_version" - 1))
         echo "$version"
@@ -113,7 +113,7 @@ tasks:
     if: ${{ tasks.detect-changes.values.any-packages-changed }}
     call: ${{ run.dir }}/package.yml
     parallel:
-      tasks-limit: 20
+      tasks-limit: 100
       values: ${{ tasks.detect-changes.values.packages }}
     init:
       directory: ${{ parallel.directory }}

--- a/.rwx/package.yml
+++ b/.rwx/package.yml
@@ -111,17 +111,11 @@ tasks:
     run: |
       if [[ -f "$DIRECTORY/rwx-test-base.json" ]]; then
         jq '[.[] | select(has("image"))]' "$DIRECTORY/rwx-test-base.json" | tee $RWX_VALUES/base-images
-        jq '[.[] | select(has("os"))]' "$DIRECTORY/rwx-test-base.json" | tee $RWX_VALUES/base-images-legacy
       else
         echo '[{"image": "ubuntu:24.04", "config": "rwx/base 1.0.0", "arch": "x86_64"}]' | tee $RWX_VALUES/base-images
-        echo '[]' | tee $RWX_VALUES/base-images-legacy
       fi
       echo -n $(jq 'length > 0' $RWX_VALUES/base-images) > $RWX_VALUES/any-base-images
-      echo -n $(jq 'length > 0' $RWX_VALUES/base-images-legacy) > $RWX_VALUES/any-base-images-legacy
       cp "$DIRECTORY/rwx-test.yml" test-run.yml
-      cp "$DIRECTORY/rwx-test.yml" test-run-legacy.yml
-      sed -i 's/image: \${{ init.base-image }}/os: \${{ init.base-os }}/' test-run-legacy.yml
-      sed -i 's/config: \${{ init.base-config }}/tag: \${{ init.base-tag }}/' test-run-legacy.yml
     filter:
       - ${{ init.directory }}
     env:
@@ -130,8 +124,6 @@ tasks:
       artifacts:
         - key: test-run
           path: test-run.yml
-        - key: test-run-legacy
-          path: test-run-legacy.yml
 
   - key: test
     if: ${{ tasks.generate-test.values.any-base-images }}
@@ -145,22 +137,9 @@ tasks:
       base-config: ${{ parallel.config }}
       base-arch: ${{ parallel.arch }}
 
-  - key: test-legacy
-    if: ${{ tasks.generate-test.values.any-base-images-legacy }}
-    call: ${{ tasks.generate-test.artifacts.test-run-legacy }}
-    parallel:
-      values: ${{ tasks.generate-test.values.base-images-legacy }}
-    init:
-      package-digest: ${{ tasks.package.values.digest }}
-      base-kind: os
-      base-os: ${{ parallel.os }}
-      base-tag: ${{ parallel.tag }}
-      base-arch: ${{ parallel.arch }}
-      base-image: ""
-
   - key: publish
     if: ${{ init.publish }}
-    after: ${{ (test.succeeded || test.skipped) && (test-legacy.succeeded || test-legacy.skipped) }}
+    after: ${{ test.succeeded || test.skipped }}
     run: |
       curl \
         --request POST \

--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -8,7 +8,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -30,7 +30,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -50,7 +50,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -73,7 +73,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -96,7 +96,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -119,14 +119,14 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
 
   - key: chained-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-other-role
@@ -149,14 +149,14 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
       profile-name: your-profile
 
   - key: chained-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       source-profile-name: your-profile
       region: us-east-2
@@ -210,7 +210,7 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
@@ -261,14 +261,14 @@ tasks:
     call: aws/install-cli 1.0.8
 
   - key: assume-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
 
   - key: chain-role
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-other-role

--- a/aws/assume-role/rwx-package.yml
+++ b/aws/assume-role/rwx-package.yml
@@ -1,37 +1,39 @@
-name: aws/assume-role
-version: 2.0.10
-description: Assume an AWS role
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/aws/assume-role
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: aws/assume-role
+  version: 2.1.0
+  description: Assume an AWS role
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/aws/assume-role
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  region:
-    description: "The AWS region (e.g. us-east-2)."
-    required: true
-  role-to-assume:
-    description: "The ARN of the AWS role to be assumed (e.g. arn:aws:iam::your-account-id:role/your-role)."
-    required: true
-  role-duration-seconds:
-    description: "The role duration in seconds."
-    default: 900
-  role-session-name:
-    description: "The name of the session."
-    required: false
-  profile-name:
-    description: "The profile under which the credentials will be configured."
-    default: "default"
-  oidc-token-env-var:
-    description: "The environment variable that contains the OIDC token."
-    default: "AWS_OIDC_TOKEN"
-  oidc-token-path-env-var:
-    description: "The environment variable that contains the path to the OIDC token file."
-    default: "AWS_OIDC_TOKEN_PATH"
-  role-chaining:
-    description: "Enable role chaining."
-    default: false
-  source-profile-name:
-    description: "The profile used to assume the chained role (only used with role-chaining is enabled)."
-    default: "default"
+  parameters:
+    region:
+      description: "The AWS region (e.g. us-east-2)."
+      required: true
+    role-to-assume:
+      description: "The ARN of the AWS role to be assumed (e.g. arn:aws:iam::your-account-id:role/your-role)."
+      required: true
+    role-duration-seconds:
+      description: "The role duration in seconds."
+      default: 900
+    role-session-name:
+      description: "The name of the session."
+      required: false
+    profile-name:
+      description: "The profile under which the credentials will be configured."
+      default: "default"
+    oidc-token-env-var:
+      description: "The environment variable that contains the OIDC token."
+      default: "AWS_OIDC_TOKEN"
+    oidc-token-path-env-var:
+      description: "The environment variable that contains the path to the OIDC token file."
+      default: "AWS_OIDC_TOKEN_PATH"
+    role-chaining:
+      description: "Enable role chaining."
+      default: false
+    source-profile-name:
+      description: "The profile used to assume the chained role (only used with role-chaining is enabled)."
+      default: "default"
 
 tasks:
   - key: produce-assume-role-hooks

--- a/aws/install-cli/README.md
+++ b/aws/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the AWS CLI:
 ```yaml
 tasks:
   - key: aws-cli
-    call: aws/install-cli 1.0.12
+    call: aws/install-cli 1.1.0
 ```
 
 To install a specific version of the AWS CLI (only v2 of the AWS CLI is supported):
@@ -13,7 +13,7 @@ To install a specific version of the AWS CLI (only v2 of the AWS CLI is supporte
 ```yaml
 tasks:
   - key: aws-cli
-    call: aws/install-cli 1.0.12
+    call: aws/install-cli 1.1.0
     with:
       cli-version: "2.15.13"
 ```

--- a/aws/install-cli/rwx-package.yml
+++ b/aws/install-cli/rwx-package.yml
@@ -1,16 +1,19 @@
-name: aws/install-cli
-version: 1.0.12
-description: Install the AWS CLI
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/aws/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: aws/install-cli
+  version: 1.1.0
+  description: Install the AWS CLI
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/aws/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  cli-version:
-    description: "Version of the CLI to install"
-    required: false
+  parameters:
+    cli-version:
+      description: "Version of the CLI to install"
+      required: false
 
 tasks:
   - key: install-unzip-if-necessary
+    use: package.use
     run: |
       if ! command -v unzip &> /dev/null; then
         source "$RWX_PACKAGE_PATH/rwx-utils.sh"
@@ -25,6 +28,7 @@ tasks:
       fi
     filter: []
   - key: install-gpg-if-necessary
+    use: package.use
     run: |
       if ! command -v gpg &> /dev/null; then
         source "$RWX_PACKAGE_PATH/rwx-utils.sh"

--- a/azure/auth-oidc/README.md
+++ b/azure/auth-oidc/README.md
@@ -12,7 +12,7 @@ tasks:
     call: azure/install-cli 1.0.8
 
   - key: azure-auth
-    call: azure/auth-oidc 2.0.0
+    call: azure/auth-oidc 2.1.0
     with:
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
@@ -37,7 +37,7 @@ tasks:
     call: azure/install-cli 1.0.8
 
   - key: azure-auth
-    call: azure/auth-oidc 2.0.0
+    call: azure/auth-oidc 2.1.0
     with:
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}
@@ -78,7 +78,7 @@ tasks:
     call: azure/install-cli 1.0.8
 
   - key: azure-auth
-    call: azure/auth-oidc 2.0.0
+    call: azure/auth-oidc 2.1.0
     with:
       client-id: ${{ vaults.your-vault.secrets.your-azure-client-id }}
       tenant-id: ${{ vaults.your-vault.secrets.your-azure-tenant-id }}

--- a/azure/auth-oidc/rwx-package.yml
+++ b/azure/auth-oidc/rwx-package.yml
@@ -1,30 +1,32 @@
-name: azure/auth-oidc
-version: 2.0.0
-description: Authenticate the Azure CLI via OIDC
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/azure/auth-oidc
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: azure/auth-oidc
+  version: 2.1.0
+  description: Authenticate the Azure CLI via OIDC
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/azure/auth-oidc
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  client-id:
-    description: "The client id of a service principal or a user-assigned managed identity"
-    required: true
-  tenant-id:
-    description: "The tenant id"
-    required: true
-  subscription-id:
-    description: "The subscription id"
-    required: false
-    default: ""
-  allow-no-subscription:
-    description: "Whether it is permissible to have no subscriptions associated to the client id (for use in managing tenant-level resources)"
-    required: false
-    default: "false"
-  oidc-token-env-var:
-    description: "The environment variable that contains the OIDC token."
-    default: "AZURE_OIDC_TOKEN"
-  oidc-token-path-env-var:
-    description: "The environment variable that contains the path to the OIDC token file."
-    default: "AZURE_OIDC_TOKEN_PATH"
+  parameters:
+    client-id:
+      description: "The client id of a service principal or a user-assigned managed identity"
+      required: true
+    tenant-id:
+      description: "The tenant id"
+      required: true
+    subscription-id:
+      description: "The subscription id"
+      required: false
+      default: ""
+    allow-no-subscription:
+      description: "Whether it is permissible to have no subscriptions associated to the client id (for use in managing tenant-level resources)"
+      required: false
+      default: "false"
+    oidc-token-env-var:
+      description: "The environment variable that contains the OIDC token."
+      default: "AZURE_OIDC_TOKEN"
+    oidc-token-path-env-var:
+      description: "The environment variable that contains the path to the OIDC token file."
+      default: "AZURE_OIDC_TOKEN_PATH"
 
 tasks:
   - key: produce-auth-hooks

--- a/azure/install-cli/README.md
+++ b/azure/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Azure CLI:
 ```yaml
 tasks:
   - key: azure-cli
-    call: azure/install-cli 1.0.11
+    call: azure/install-cli 1.1.0
 ```
 
 To install a specific version of the Azure CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Azure CLI:
 ```yaml
 tasks:
   - key: azure-cli
-    call: azure/install-cli 1.0.11
+    call: azure/install-cli 1.1.0
     with:
       version: "2.65.0"
 ```

--- a/azure/install-cli/rwx-package.yml
+++ b/azure/install-cli/rwx-package.yml
@@ -1,16 +1,19 @@
-name: azure/install-cli
-version: 1.0.11
-description: Install the Azure CLI
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/azure/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: azure/install-cli
+  version: 1.1.0
+  description: Install the Azure CLI
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/azure/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  version:
-    description: "Version of the CLI to install"
-    default: "latest"
+  parameters:
+    version:
+      description: "Version of the CLI to install"
+      default: "latest"
 
 tasks:
   - key: install-cli
+    use: package.use
     run: |
       # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
 
@@ -76,5 +79,6 @@ tasks:
       echo ""
       echo "Installed Azure CLI:"
       az version
+    filter: []
     env:
       VERSION: ${{ params.version }}

--- a/depot/install-cli/README.md
+++ b/depot/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Depot CLI:
 ```yaml
 tasks:
   - key: depot-cli
-    call: depot/install-cli 1.0.5
+    call: depot/install-cli 1.1.0
 ```
 
 To install a specific version of the Depot CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Depot CLI:
 ```yaml
 tasks:
   - key: depot-cli
-    call: depot/install-cli 1.0.5
+    call: depot/install-cli 1.1.0
     with:
       cli-version: "2.53.0"
 ```

--- a/depot/install-cli/rwx-package.yml
+++ b/depot/install-cli/rwx-package.yml
@@ -1,16 +1,19 @@
-name: depot/install-cli
-version: 1.0.5
-description: Install the Depot CLI
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/depot/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: depot/install-cli
+  version: 1.1.0
+  description: Install the Depot CLI
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/depot/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  cli-version:
-    description: "Version of the CLI to install"
-    default: "latest"
+  parameters:
+    cli-version:
+      description: "Version of the CLI to install"
+      default: "latest"
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
 
@@ -26,3 +29,4 @@ tasks:
       rm -rf "$DEPOT_INSTALL_DIR"
       rm ./install-cli.sh
       depot --version
+    filter: []

--- a/docker/login-hook/README.md
+++ b/docker/login-hook/README.md
@@ -15,7 +15,7 @@ of the registry as the `registry` parameter to this leaf.
 ```yaml
 tasks:
   - key: docker-login
-    call: docker/login-hook 1.0.5
+    call: docker/login-hook 1.1.0
     with:
       username: my-username
 
@@ -32,7 +32,7 @@ Override the registry:
 ```yaml
 tasks:
   - key: docker-login
-    call: docker/login-hook 1.0.5
+    call: docker/login-hook 1.1.0
     with:
       username: my-username
       registry: custom-registry.your-company.com
@@ -53,12 +53,12 @@ However, you'll need to specify `password-env-name` to prevent conflicts.
 ```yaml
 tasks:
   - key: docker-login-dockerhub
-    call: docker/login-hook 1.0.5
+    call: docker/login-hook 1.1.0
     with:
       username: my-username
 
   - key: docker-login-other-registry
-    call: docker/login-hook 1.0.5
+    call: docker/login-hook 1.1.0
     with:
       username: my-username
       password-env-name: OTHER_REGISTRY_PASSWORD
@@ -82,7 +82,7 @@ organization name for the username and the access token for the password:
 ```yaml
 tasks:
   - key: docker-login
-    call: docker/login-hook 1.0.5
+    call: docker/login-hook 1.1.0
     with:
       username: my-docker-organization
 

--- a/docker/login-hook/rwx-package.yml
+++ b/docker/login-hook/rwx-package.yml
@@ -1,19 +1,21 @@
-name: docker/login-hook
-version: 1.0.5
-description: Mint hook to log in to a Docker registry
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/docker/login-hook
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: docker/login-hook
+  version: 1.1.0
+  description: Mint hook to log in to a Docker registry
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/docker/login-hook
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  username:
-    description: "The username to log in with."
-    required: true
-  password-env-name:
-    description: "The environment variable name that contains the Docker registry token or password."
-    default: DOCKER_PASSWORD
-  registry:
-    description: "The Docker registry to log in to."
-    default: docker.io
+  parameters:
+    username:
+      description: "The username to log in with."
+      required: true
+    password-env-name:
+      description: "The environment variable name that contains the Docker registry token or password."
+      default: DOCKER_PASSWORD
+    registry:
+      description: "The Docker registry to log in to."
+      default: docker.io
 
 tasks:
   - key: produce-login-hooks

--- a/dotnet/install/README.md
+++ b/dotnet/install/README.md
@@ -7,7 +7,7 @@ Install one or more .NET SDK versions.
 ```yaml
 tasks:
   - key: dotnet
-    call: dotnet/install 1.0.1
+    call: dotnet/install 1.1.0
     with:
       dotnet-channel: "8.0"
 ```
@@ -18,7 +18,7 @@ tasks:
 tasks:
   - key: dotnet
     use: code
-    call: dotnet/install 1.0.1
+    call: dotnet/install 1.1.0
     with:
       global-json-file: global.json
     filter:
@@ -30,7 +30,7 @@ tasks:
 ```yaml
 tasks:
   - key: dotnet
-    call: dotnet/install 1.0.1
+    call: dotnet/install 1.1.0
     with:
       dotnet-channels: '["8.0", "9.0", "10.0"]'
       dotnet-quality: preview

--- a/dotnet/install/rwx-package.yml
+++ b/dotnet/install/rwx-package.yml
@@ -1,25 +1,28 @@
-name: dotnet/install
-version: 1.0.1
-description: Install the .NET SDK
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/dotnet/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: dotnet/install
+  version: 1.1.0
+  description: Install the .NET SDK
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/dotnet/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  dotnet-channel:
-    description: "Single .NET SDK channel/version to install, eg. 8.0"
-    required: false
-  dotnet-channels:
-    description: "Array-style list of .NET SDK channels/versions to install in one call, eg. [\"8.0\", \"9.0\"]"
-    required: false
-  dotnet-quality:
-    description: "Optional .NET SDK quality, eg. ga, preview, daily"
-    required: false
-  global-json-file:
-    description: "Path to a global.json file used to determine the SDK version"
-    required: false
+  parameters:
+    dotnet-channel:
+      description: "Single .NET SDK channel/version to install, eg. 8.0"
+      required: false
+    dotnet-channels:
+      description: 'Array-style list of .NET SDK channels/versions to install in one call, eg. ["8.0", "9.0"]'
+      required: false
+    dotnet-quality:
+      description: "Optional .NET SDK quality, eg. ga, preview, daily"
+      required: false
+    global-json-file:
+      description: "Path to a global.json file used to determine the SDK version"
+      required: false
 
 tasks:
   - key: install-libicu-dev
+    use: package.use
     run: |
       if ! dpkg -s libicu-dev >/dev/null 2>&1; then
         source "$RWX_PACKAGE_PATH/rwx-utils.sh"
@@ -27,7 +30,8 @@ tasks:
         rwx_maybe_sudo apt-get install -y --no-install-recommends libicu-dev
         rwx_maybe_sudo apt-get clean
       fi
- 
+    filter: []
+
   - key: install-dotnet
     use: install-libicu-dev
     run: |
@@ -38,6 +42,8 @@ tasks:
       fi
 
       $RWX_PACKAGE_PATH/bin/install-dotnet
+    filter:
+      - '${{ params.global-json-file == "" ? "___NOMATCH" : params.global-json-file }}'
     env:
       DOTNET_CHANNEL: ${{ params.dotnet-channel }}
       DOTNET_CHANNELS: ${{ params.dotnet-channels }}

--- a/elixir-lang/install/README.md
+++ b/elixir-lang/install/README.md
@@ -11,7 +11,7 @@ tasks:
 
   - key: elixir
     use: erlang
-    call: elixir-lang/install 1.1.5
+    call: elixir-lang/install 1.2.0
     with:
       elixir-version: "1.17.2"
 ```

--- a/elixir-lang/install/rwx-package.yml
+++ b/elixir-lang/install/rwx-package.yml
@@ -1,16 +1,19 @@
-name: elixir-lang/install
-version: 1.1.5
-description: Install Elixir, a dynamic, functional language for building scalable and maintainable applications.
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/elixir-lang/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: elixir-lang/install
+  version: 1.2.0
+  description: Install Elixir, a dynamic, functional language for building scalable and maintainable applications.
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/elixir-lang/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  elixir-version:
-    description: "Version of Elixir to install"
-    required: true
+  parameters:
+    elixir-version:
+      description: "Version of Elixir to install"
+      required: true
 
 tasks:
   - key: install
+    use: [package.use]
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
 
@@ -82,5 +85,6 @@ tasks:
       elixir --version | tee /dev/stderr | grep "^Elixir ${ELIXIR_VERSION}"
 
       echo "Installed Elixir v${ELIXIR_VERSION} to ${ELIXIR_ROOT}"
+    filter: []
     env:
       ELIXIR_VERSION: ${{ params.elixir-version }}

--- a/erlang/install/README.md
+++ b/erlang/install/README.md
@@ -5,7 +5,7 @@ To install Erlang:
 ```yaml
 tasks:
   - key: erlang
-    call: erlang/install 1.1.4
+    call: erlang/install 1.2.0
     with:
       erlang-version: 28.1
 ```

--- a/erlang/install/rwx-package.yml
+++ b/erlang/install/rwx-package.yml
@@ -1,16 +1,19 @@
-name: erlang/install
-version: 1.1.4
-description: Install Erlang, a programming language used to build massively scalable soft real-time systems with requirements on high availability
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/erlang/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: erlang/install
+  version: 1.2.0
+  description: Install Erlang, a programming language used to build massively scalable soft real-time systems with requirements on high availability
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/erlang/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  erlang-version:
-    description: "Version of Erlang to install"
-    required: true
+  parameters:
+    erlang-version:
+      description: "Version of Erlang to install"
+      required: true
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if [ "$(rwx_os_name)" != "ubuntu" ]; then
@@ -80,5 +83,6 @@ tasks:
       erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^${ERLANG_VERSION}$"
 
       echo "Installed OTP-${ERLANG_VERSION} to ${ERL_ROOT}"
+    filter: []
     env:
       ERLANG_VERSION: ${{ params.erlang-version }}

--- a/git/clone/README.md
+++ b/git/clone/README.md
@@ -31,7 +31,7 @@ tasks:
 
   - key: code
     use: system-packages
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: ...
 ```
@@ -41,7 +41,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -67,7 +67,7 @@ If you're using GitHub, RWX will automatically provide a token that you can use 
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -79,7 +79,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -97,7 +97,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -174,7 +174,7 @@ For most usage, it's as easy as:
 tasks:
   - key: code
 -    call: git/clone 1.9.5
-+    call: git/clone 2.0.8
++    call: git/clone 2.1.0
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}

--- a/git/clone/rwx-package.yml
+++ b/git/clone/rwx-package.yml
@@ -1,46 +1,49 @@
-name: git/clone
-version: 2.0.8
-description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/git/clone
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: git/clone
+  version: 2.1.0
+  description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/git/clone
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  github-token:
-    description: "Token to clone from GitHub over HTTPS"
-    required: false
-  lfs:
-    description: Whether to download Git-LFS files
-    default: false
-  path:
-    description: "The relative path within the workspace into which the repository will be cloned"
-    default: "./"
-  preserve-git-dir:
-    description: "Whether or not to preserve the .git directory. Set to true if you want to perform git operations like committing after cloning. Preserving the .git directory will decrease the likelihood of cache hits when a file filter is not specified."
-    default: false
-  ref:
-    description: "The ref to check out of the git repository"
-    required: true
-  meta-ref:
-    description: "Optional override for RWX_GIT_REF. This value is used as-is (for example refs/heads/main, refs/tags/v1.0.0, or main)."
-    required: false
-  repository:
-    description: "The url of a git repository."
-    required: true
-  ssh-key:
-    description: "The ssh key to use if cloning over ssh"
-    required: false
-  fetch-full-depth:
-    description: "Whether to use a full-depth fetch instead of a shallow fetch. This defaults to `false`, including when `preserve-git-dir` is `true`. Typically, leaving this as `false` results in better cloning performance within RWX. However, for certain large repositories or workflows that require full history, a full-depth fetch may be preferable."
-    default: false
-  submodules:
-    description: Whether to clone submodules
-    default: true
-  tool-cache-key-prefix:
-    description: Optional prefix for the tool cache key
-    default: git-clone
+  parameters:
+    github-token:
+      description: "Token to clone from GitHub over HTTPS"
+      required: false
+    lfs:
+      description: Whether to download Git-LFS files
+      default: false
+    path:
+      description: "The relative path within the workspace into which the repository will be cloned"
+      default: "./"
+    preserve-git-dir:
+      description: "Whether or not to preserve the .git directory. Set to true if you want to perform git operations like committing after cloning. Preserving the .git directory will decrease the likelihood of cache hits when a file filter is not specified."
+      default: false
+    ref:
+      description: "The ref to check out of the git repository"
+      required: true
+    meta-ref:
+      description: "Optional override for RWX_GIT_REF. This value is used as-is (for example refs/heads/main, refs/tags/v1.0.0, or main)."
+      required: false
+    repository:
+      description: "The url of a git repository."
+      required: true
+    ssh-key:
+      description: "The ssh key to use if cloning over ssh"
+      required: false
+    fetch-full-depth:
+      description: "Whether to use a full-depth fetch instead of a shallow fetch. This defaults to `false`, including when `preserve-git-dir` is `true`. Typically, leaving this as `false` results in better cloning performance within RWX. However, for certain large repositories or workflows that require full history, a full-depth fetch may be preferable."
+      default: false
+    submodules:
+      description: Whether to clone submodules
+      default: true
+    tool-cache-key-prefix:
+      description: Optional prefix for the tool cache key
+      default: git-clone
 
 tasks:
   - key: setup
+    use: [package.use]
     run: |
       . "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if ! rwx_os_package_manager_in apt apk; then
@@ -155,6 +158,7 @@ tasks:
         echo "Setting credential.helper to clone using github-token"
         printf '%s' '!sh -c "echo username=x-access-token && echo password=${GITHUB_TOKEN}"' > "$RWX_VALUES/credential-helper"
       fi
+    filter: []
     env:
       GIT_SSH_KEY: ${{ params.ssh-key }}
       CHECKOUT_REPOSITORY: ${{ params.repository }}
@@ -181,6 +185,7 @@ tasks:
       SUBMODULES: ${{ params.submodules }}
       TOOL_CACHE_KEY_PREFIX: ${{ params.tool-cache-key-prefix }}
     filter:
+      workspace: []
       ${{ run.dir }}: [.patches]
     cache: ${{ params.ref =~ '^[0-9a-f]{40}$' }}
 
@@ -215,6 +220,7 @@ tasks:
     use: [setup, install-lfs]
     run: $RWX_PACKAGE_PATH/bin/git-clone
     tool-cache: ${{ tasks.get-latest-sha-for-ref.values.tool-cache-key }}
+    filter: []
     env:
       GIT_LFS_SKIP_SMUDGE: 1
       GIT_SSH_KEY:

--- a/github/compare/README.md
+++ b/github/compare/README.md
@@ -19,7 +19,7 @@ tasks:
 
   - key: go-files
     use: github-cli
-    call: github/compare 1.0.8
+    call: github/compare 1.1.0
     with:
       repository: my-organization/my-repository
       base-ref: abc123
@@ -41,7 +41,7 @@ tasks:
 
   - key: go-files
     use: github-cli
-    call: github/compare 1.0.8
+    call: github/compare 1.1.0
     with:
       repository: my-organization/my-repository
       base-ref: abc123
@@ -79,7 +79,7 @@ tasks:
 
   - key: go-files
     use: github-cli
-    call: github/compare 1.0.8
+    call: github/compare 1.1.0
     with:
       repository: my-organization/my-repository
       base-ref: ${{ init.base-ref }}
@@ -111,7 +111,7 @@ tasks:
 
   - key: go-files
     use: github-cli
-    call: github/compare 1.0.8
+    call: github/compare 1.1.0
     with:
       repository: my-organization/my-repository
       base-ref: ${{ init.base-ref }}

--- a/github/compare/rwx-package.yml
+++ b/github/compare/rwx-package.yml
@@ -1,31 +1,34 @@
-name: github/compare
-version: 1.0.8
-description: Compare two git refs in GitHub and check if certain files changed
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/compare
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: github/compare
+  version: 1.1.0
+  description: Compare two git refs in GitHub and check if certain files changed
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/compare
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  repository:
-    description: The owner/repository-name of your GitHub repository (e.g. `my-organization/my-repository`)
-    required: true
-  base-ref:
-    description: "The git ref to compare `head-ref` against"
-    required: true
-  head-ref:
-    description: "The git ref to compare against `base-ref`"
-    required: true
-  github-token:
-    description: "A GitHub token with read access to the repository. Usually `${{ github.token }}`."
-    required: false
-  patterns:
-    description: "A newline-separated list of glob patterns to match against the changed files"
-    required: false
+  parameters:
+    repository:
+      description: The owner/repository-name of your GitHub repository (e.g. `my-organization/my-repository`)
+      required: true
+    base-ref:
+      description: "The git ref to compare `head-ref` against"
+      required: true
+    head-ref:
+      description: "The git ref to compare against `base-ref`"
+      required: true
+    github-token:
+      description: "A GitHub token with read access to the repository. Usually `${{ github.token }}`."
+      required: false
+    patterns:
+      description: "A newline-separated list of glob patterns to match against the changed files"
+      required: false
 
-outputs:
-  values-from: [compare]
+  outputs:
+    values-from: [compare]
 
 tasks:
   - key: shas
+    use: [package.use]
     run: |
       echo "Base ref resolves to:"
       if [[ "${BASE_REF}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -55,6 +58,7 @@ tasks:
           echo "${sha}" | tee $RWX_VALUES/head-sha
         fi
       fi
+    filter: []
     env:
       GITHUB_TOKEN:
         value: ${{ params.github-token }}
@@ -65,6 +69,7 @@ tasks:
     cache: ${{ params.base-ref =~ '^[0-9a-f]{40}$' && params.head-ref =~ '^[0-9a-f]{40}$' }}
 
   - key: compare
+    use: [package.use]
     run: |
       gh api "/repos/${REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}" > compare.json
 
@@ -88,6 +93,7 @@ tasks:
         echo "true" > $RWX_VALUES/has-changes
         echo "true" > $RWX_VALUES/have-changes
       fi
+    filter: []
     env:
       GITHUB_TOKEN:
         value: ${{ params.github-token }}

--- a/github/create-pull-request/README.md
+++ b/github/create-pull-request/README.md
@@ -60,7 +60,7 @@ tasks:
     run: rwx packages update | tee $RWX_VALUES/update-output
 
   - key: create-pull-request
-    call: github/create-pull-request 1.0.7
+    call: github/create-pull-request 1.1.0
     use: [update-packages]
     with:
       github-token: ${{ github-apps.your-orgs-bot.token }}
@@ -73,7 +73,7 @@ tasks:
 
 ```yaml
   - key: create-pull-request
-    call: github/create-pull-request 1.0.7
+    call: github/create-pull-request 1.1.0
     use: [update-packages]
     with:
       github-token: ${{ github-apps.your-orgs-bot.token }}

--- a/github/create-pull-request/rwx-package.yml
+++ b/github/create-pull-request/rwx-package.yml
@@ -1,38 +1,40 @@
-name: github/create-pull-request
-version: 1.0.7
-description: Creates a pull request
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/create-pull-request
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: github/create-pull-request
+  version: 1.1.0
+  description: Creates a pull request
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/create-pull-request
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  github-token:
-    description: "The GitHub token to a private app"
-    required: true
-  branch-prefix:
-    description: "Branch prefix to idenitfy existing pull request"
-    required: true
-  pull-request-title:
-    description: "The title to use for the pull request"
-    required: true
-  pull-request-body:
-    description: "The body to use for the pull request"
-    required: true
-  enable-auto-merge:
-    description: "Enable squash auto-merge on the pull request (requires repository auto-merge support)"
-    default: false
-  reviewers:
-    description: "Comma-separated list of reviewers to request (usernames and/or org/team slugs in `gh`'s native format)"
-    default: ""
+  parameters:
+    github-token:
+      description: "The GitHub token to a private app"
+      required: true
+    branch-prefix:
+      description: "Branch prefix to idenitfy existing pull request"
+      required: true
+    pull-request-title:
+      description: "The title to use for the pull request"
+      required: true
+    pull-request-body:
+      description: "The body to use for the pull request"
+      required: true
+    enable-auto-merge:
+      description: "Enable squash auto-merge on the pull request (requires repository auto-merge support)"
+      default: false
+    reviewers:
+      description: "Comma-separated list of reviewers to request (usernames and/or org/team slugs in `gh`'s native format)"
+      default: ""
 
-outputs:
-  values-from: [create-or-update-pull-request]
+  outputs:
+    values-from: [create-or-update-pull-request]
 
 tasks:
   - key: gh-cli
-    call: github/install-cli 1.0.10
+    call: github/install-cli 1.0.11
 
   - key: create-or-update-pull-request
-    use: [gh-cli]
+    use: [package.use, gh-cli]
     cache: false
     run: |
       # ensure these values are always present

--- a/github/install-cli/README.md
+++ b/github/install-cli/README.md
@@ -5,5 +5,5 @@ To install the latest version of the GitHub CLI:
 ```yaml
 tasks:
   - key: github-cli
-    call: github/install-cli 1.0.11
+    call: github/install-cli 1.1.0
 ```

--- a/github/install-cli/rwx-package.yml
+++ b/github/install-cli/rwx-package.yml
@@ -1,11 +1,14 @@
-name: github/install-cli
-version: 1.0.11
-description: Install the GitHub CLI, gh. It is GitHub on the command line.
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: github/install-cli
+  version: 1.1.0
+  description: Install the GitHub CLI, gh. It is GitHub on the command line.
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/github/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if ! rwx_os_package_manager_in apt; then
@@ -21,3 +24,4 @@ tasks:
       rwx_maybe_sudo apt-get install -y gh
       rwx_maybe_sudo apt-get clean
       gh --version
+    filter: []

--- a/golang/install/README.md
+++ b/golang/install/README.md
@@ -5,7 +5,7 @@ To install the latest version of go:
 ```yaml
 tasks:
   - key: go
-    call: golang/install 1.2.2
+    call: golang/install 1.3.0
 ```
 
 To install a specific version:
@@ -13,7 +13,7 @@ To install a specific version:
 ```yaml
 tasks:
   - key: go
-    call: golang/install 1.2.2
+    call: golang/install 1.3.0
     with:
       go-version: "1.21.5"
 ```

--- a/golang/install/rwx-package.yml
+++ b/golang/install/rwx-package.yml
@@ -1,16 +1,20 @@
-name: golang/install
-version: 1.2.2
-description: Install the Go programming language
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/golang/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: golang/install
+  version: 1.3.0
+  description: Install the Go programming language
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/golang/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  go-version:
-    description: "Version of Go to install"
-    default: "latest"
+  parameters:
+    go-version:
+      description: "Version of Go to install"
+      default: "latest"
 
 tasks:
   - key: install
+    use: package.use
     run: $RWX_PACKAGE_PATH/bin/install-go
+    filter: []
     env:
       GO_VERSION: ${{ params.go-version }}

--- a/golang/mod-download/README.md
+++ b/golang/mod-download/README.md
@@ -23,7 +23,7 @@ tasks:
 
   - key: go-modules
     use: [go, code]
-    call: golang/mod-download 1.0.2
+    call: golang/mod-download 1.1.0
     filter: [go.mod, go.sum]
     with:
       tool-cache: my-repo-go-modules
@@ -38,7 +38,7 @@ If your Go project is not in the workspace root, you can specify a path:
 ```yaml
   - key: go-modules
     use: [go, code]
-    call: golang/mod-download 1.0.2
+    call: golang/mod-download 1.1.0
     filter: [path/to/go.mod, path/to/go.sum]
     with:
       path: path/to

--- a/golang/mod-download/rwx-package.yml
+++ b/golang/mod-download/rwx-package.yml
@@ -1,18 +1,21 @@
-name: golang/mod-download
-version: 1.0.2
-description: Downloads and caches all of your Go modules without requiring your source code
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/golang/mod-download
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: golang/mod-download
+  version: 1.1.0
+  description: Downloads and caches all of your Go modules without requiring your source code
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/golang/mod-download
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  path:
-    description: "The relative path within the workspace to the directory containing the go.mod and go.sum files"
-    default: "./"
-  tool-cache:
-    description: The tool cache key of the module download
+  parameters:
+    path:
+      description: "The relative path within the workspace to the directory containing the go.mod and go.sum files"
+      default: "./"
+    tool-cache:
+      description: The tool cache key of the module download
 
 tasks:
   - key: mod-download
+    use: [package.use]
     tool-cache: ${{ params.tool-cache }}
     agent:
       tmpfs: true

--- a/google-cloud/auth-credentials/README.md
+++ b/google-cloud/auth-credentials/README.md
@@ -11,7 +11,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-credentials 2.0.0
+    call: google-cloud/auth-credentials 2.1.0
 
   - key: task-that-needs-gcloud
     use: [install-gcloud, gcloud-auth]
@@ -30,7 +30,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-credentials 2.0.0
+    call: google-cloud/auth-credentials 2.1.0
     with:
       project-id: identifier-of-my-project
 
@@ -51,7 +51,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-credentials 2.0.0
+    call: google-cloud/auth-credentials 2.1.0
 
   - key: task-that-does-not-need-gcloud
     use: [install-gcloud, gcloud-auth]
@@ -87,7 +87,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-credentials 2.0.0
+    call: google-cloud/auth-credentials 2.1.0
 
   - key: your-task
     use: [install-gcloud, gcloud-auth]

--- a/google-cloud/auth-credentials/rwx-package.yml
+++ b/google-cloud/auth-credentials/rwx-package.yml
@@ -1,16 +1,18 @@
-name: google-cloud/auth-credentials
-version: 2.0.0
-description: Authenticate to Google Cloud with credentials JSON
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/auth-credentials
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: google-cloud/auth-credentials
+  version: 2.1.0
+  description: Authenticate to Google Cloud with credentials JSON
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/auth-credentials
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  project-id:
-    description: "The default project to select once authenticated"
-    required: false
-  credentials-json-env-var:
-    description: "The environment variable that contains the credentials JSON."
-    default: "GCP_CREDENTIALS_JSON"
+  parameters:
+    project-id:
+      description: "The default project to select once authenticated"
+      required: false
+    credentials-json-env-var:
+      description: "The environment variable that contains the credentials JSON."
+      default: "GCP_CREDENTIALS_JSON"
 
 tasks:
   - key: produce-auth-hooks

--- a/google-cloud/auth-oidc/README.md
+++ b/google-cloud/auth-oidc/README.md
@@ -24,7 +24,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.2
+    call: google-cloud/auth-oidc 2.1.0
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -45,7 +45,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.2
+    call: google-cloud/auth-oidc 2.1.0
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
       service-account: ${{ vaults.your-vault.secrets.SERVICE_ACCOUNT }}
@@ -65,7 +65,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.2
+    call: google-cloud/auth-oidc 2.1.0
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
       project-id: identifier-of-my-project
@@ -85,7 +85,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.2
+    call: google-cloud/auth-oidc 2.1.0
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -126,7 +126,7 @@ tasks:
     call: google-cloud/install-cli 1.1.6
 
   - key: gcloud-auth
-    call: google-cloud/auth-oidc 2.0.2
+    call: google-cloud/auth-oidc 2.1.0
     with:
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
 

--- a/google-cloud/auth-oidc/rwx-package.yml
+++ b/google-cloud/auth-oidc/rwx-package.yml
@@ -1,31 +1,33 @@
-name: google-cloud/auth-oidc
-version: 2.0.2
-description: Authenticate to Google Cloud with OIDC and Workload Identity Federation
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/auth-oidc
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: google-cloud/auth-oidc
+  version: 2.1.0
+  description: Authenticate to Google Cloud with OIDC and Workload Identity Federation
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/auth-oidc
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  workload-identity-provider:
-    description: "The full identifier of the Workload Identity Provider"
-    required: true
-  service-account:
-    description: "The identifier of the Google Cloud service account which will be impersonated by the generated OIDC"
-    required: false
-  service-account-token-lifetime-seconds:
-    description: "Lifetime duration of the service account access token in seconds"
-    required: false
-  audience:
-    description: "The generated token's `aud` parameter, defaults to the value of `workload-identity-provider`"
-    required: false
-  project-id:
-    description: "The default project to select once authenticated"
-    required: false
-  oidc-token-env-var:
-    description: "The environment variable that contains the OIDC token."
-    default: "GCP_OIDC_TOKEN"
-  oidc-token-path-env-var:
-    description: "The environment variable that contains the path to the OIDC token file."
-    default: "GCP_OIDC_TOKEN_PATH"
+  parameters:
+    workload-identity-provider:
+      description: "The full identifier of the Workload Identity Provider"
+      required: true
+    service-account:
+      description: "The identifier of the Google Cloud service account which will be impersonated by the generated OIDC"
+      required: false
+    service-account-token-lifetime-seconds:
+      description: "Lifetime duration of the service account access token in seconds"
+      required: false
+    audience:
+      description: "The generated token's `aud` parameter, defaults to the value of `workload-identity-provider`"
+      required: false
+    project-id:
+      description: "The default project to select once authenticated"
+      required: false
+    oidc-token-env-var:
+      description: "The environment variable that contains the OIDC token."
+      default: "GCP_OIDC_TOKEN"
+    oidc-token-path-env-var:
+      description: "The environment variable that contains the path to the OIDC token file."
+      default: "GCP_OIDC_TOKEN_PATH"
 
 tasks:
   - key: produce-auth-hooks

--- a/google-cloud/install-cli/README.md
+++ b/google-cloud/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Google Cloud CLI:
 ```yaml
 tasks:
   - key: gcloud-cli
-    call: google-cloud/install-cli 1.1.8
+    call: google-cloud/install-cli 1.2.0
 ```
 
 To install a specific version of the Google Cloud CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Google Cloud CLI:
 ```yaml
 tasks:
   - key: gcloud-cli
-    call: google-cloud/install-cli 1.1.8
+    call: google-cloud/install-cli 1.2.0
     with:
       cli-version: "465.0.0"
 ```

--- a/google-cloud/install-cli/rwx-package.yml
+++ b/google-cloud/install-cli/rwx-package.yml
@@ -1,19 +1,22 @@
-name: google-cloud/install-cli
-version: 1.1.8
-description: Install the Google Cloud SDK CLI
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: google-cloud/install-cli
+  version: 1.2.0
+  description: Install the Google Cloud SDK CLI
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/google-cloud/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  cli-version:
-    description: "Version of the CLI to install"
-    default: "latest"
-  components:
-    description: "Optional space-separated list of CLI components to install"
-    default: ""
+  parameters:
+    cli-version:
+      description: "Version of the CLI to install"
+      default: "latest"
+    components:
+      description: "Optional space-separated list of CLI components to install"
+      default: ""
 
 tasks:
   - key: install-cli
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if [ "$(rwx_os_name)" != "ubuntu" ]; then
@@ -76,3 +79,4 @@ tasks:
       echo
       echo "Cleaning Google Cloud SDK backup"
       rm -rf "${install_dir}/google-cloud-sdk/.install/.backup"
+    filter: []

--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.1.12
+    call: google/install-chrome 2.2.0
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.1.12
+    call: google/install-chrome 2.2.0
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 2.1.12
+    call: google/install-chrome 2.2.0
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 2.1.12
+    call: google/install-chrome 2.2.0
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -68,7 +68,7 @@ By default, `google/install-chrome` supports tools that interact with Chrome in 
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.1.12
+  call: google/install-chrome 2.2.0
   with:
     chrome-version: stable
     install-chromedriver: true
@@ -117,7 +117,7 @@ You can also use tools that interact with headed Chrome. To do so, wrap your com
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.1.12
+  call: google/install-chrome 2.2.0
   with:
     chrome-version: stable
     install-chromedriver: true

--- a/google/install-chrome/rwx-package.yml
+++ b/google/install-chrome/rwx-package.yml
@@ -1,35 +1,38 @@
-name: google/install-chrome
-version: 2.1.12
-description: Install Google Chrome, the official web browser from Google
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/google/install-chrome
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: google/install-chrome
+  version: 2.2.0
+  description: Install Google Chrome, the official web browser from Google
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/google/install-chrome
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  chrome-version:
-    description: "Version of Chrome to install."
-    required: true
-  install-chromedriver:
-    description: "Whether a compatible Chromedriver should be installed."
-    required: false
-    default: false
-  chrome-directory:
-    description: "The directory where Chrome will be installed."
-    required: false
-    default: /opt/chrome
-  chromedriver-directory:
-    description: "The directory where Chromedriver will be installed."
-    required: false
-    default: /opt/chromedriver
-  add-to-path:
-    description: "Whether Chrome and (optionally) Chromedriver should be included in PATH."
-    required: false
-    default: true
+  parameters:
+    chrome-version:
+      description: "Version of Chrome to install."
+      required: true
+    install-chromedriver:
+      description: "Whether a compatible Chromedriver should be installed."
+      required: false
+      default: false
+    chrome-directory:
+      description: "The directory where Chrome will be installed."
+      required: false
+      default: /opt/chrome
+    chromedriver-directory:
+      description: "The directory where Chromedriver will be installed."
+      required: false
+      default: /opt/chromedriver
+    add-to-path:
+      description: "Whether Chrome and (optionally) Chromedriver should be included in PATH."
+      required: false
+      default: true
 
-outputs:
-  values-from: [install]
+  outputs:
+    values-from: [install]
 
 tasks:
   - key: resolve-chrome-version
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if ! rwx_os_name_in ubuntu; then
@@ -79,10 +82,12 @@ tasks:
       fi
     env:
       CHROME_VERSION: ${{ params.chrome-version }}
+    filter: []
     cache:
       ttl: 1 day
 
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       os_packages=""
@@ -167,6 +172,7 @@ tasks:
 
       rm -f chrome.zip
       rm -f chromedriver.zip
+    filter: []
     env:
       ADD_TO_PATH: ${{ params.add-to-path }}
       CHROME_DIRECTORY: ${{ params.chrome-directory }}

--- a/hashicorp/install-terraform/README.md
+++ b/hashicorp/install-terraform/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Terraform CLI:
 ```yaml
 tasks:
   - key: terraform
-    call: hashicorp/install-terraform 1.0.13
+    call: hashicorp/install-terraform 1.1.0
 ```
 
 To install a specific version of the Terraform CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Terraform CLI:
 ```yaml
 tasks:
   - key: terraform
-    call: hashicorp/install-terraform 1.0.13
+    call: hashicorp/install-terraform 1.1.0
     with:
       terraform-version: "1.7.3"
 ```

--- a/hashicorp/install-terraform/rwx-package.yml
+++ b/hashicorp/install-terraform/rwx-package.yml
@@ -1,16 +1,19 @@
-name: hashicorp/install-terraform
-version: 1.0.13
-description: Install the Terraform CLI, a tool for building, changing, and versioning infrastructure safely and efficiently
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/hashicorp/install-terraform
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: hashicorp/install-terraform
+  version: 1.1.0
+  description: Install the Terraform CLI, a tool for building, changing, and versioning infrastructure safely and efficiently
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/hashicorp/install-terraform
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  terraform-version:
-    description: "Version of Terraform to install"
-    default: "latest"
+  parameters:
+    terraform-version:
+      description: "Version of Terraform to install"
+      default: "latest"
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if ! rwx_os_package_manager_in apt; then
@@ -34,3 +37,4 @@ tasks:
         rwx_maybe_sudo apt-get install -y terraform=${{ params.terraform-version }}-*
       fi
       rwx_maybe_sudo apt-get clean
+    filter: []

--- a/kubernetes/install-cli/README.md
+++ b/kubernetes/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Kubernetes CLI (kubectl):
 ```yaml
 tasks:
   - key: kubectl-cli
-    call: kubernetes/install-cli 1.0.7
+    call: kubernetes/install-cli 1.1.0
 ```
 
 To install a specific version of the Kubernetes CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Kubernetes CLI:
 ```yaml
 tasks:
   - key: kubectl-cli
-    call: kubernetes/install-cli 1.0.7
+    call: kubernetes/install-cli 1.1.0
     with:
       cli-version: "1.29.2"
 ```

--- a/kubernetes/install-cli/rwx-package.yml
+++ b/kubernetes/install-cli/rwx-package.yml
@@ -1,16 +1,19 @@
-name: kubernetes/install-cli
-version: 1.0.7
-description: Install the Kubernetes CLI (kubectl)
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/kubernetes/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: kubernetes/install-cli
+  version: 1.1.0
+  description: Install the Kubernetes CLI (kubectl)
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/kubernetes/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  cli-version:
-    description: "Version of the CLI to install"
-    default: "latest"
+  parameters:
+    cli-version:
+      description: "Version of the CLI to install"
+      default: "latest"
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
 
@@ -28,3 +31,4 @@ tasks:
 
       rm kubectl kubectl.sha256
       kubectl version --client
+    filter: []

--- a/mise/install/README.md
+++ b/mise/install/README.md
@@ -10,7 +10,7 @@ tasks:
 
   - key: mise
     use: code
-    call: mise/install 1.0.1
+    call: mise/install 1.1.0
     filter:
       - mise.toml
 ```
@@ -24,7 +24,7 @@ This reads the mise config in the checkout root (`mise.toml`, `.mise.toml`, or
 tasks:
   - key: tools
     use: code
-    call: mise/install 1.0.1
+    call: mise/install 1.1.0
     with:
       mise-version: "2026.7.11"
 ```
@@ -34,7 +34,7 @@ tasks:
 ```yaml
 tasks:
   - key: mise
-    call: mise/install 1.0.1
+    call: mise/install 1.1.0
     with:
       install: "false"
 
@@ -49,7 +49,7 @@ tasks:
 tasks:
   - key: tools
     use: code
-    call: mise/install 1.0.1
+    call: mise/install 1.1.0
     with:
       working-directory: services/api
     filter:
@@ -66,7 +66,7 @@ name, so later tasks can reference a version without re-parsing the config:
 tasks:
   - key: mise
     use: code
-    call: mise/install 1.0.1
+    call: mise/install 1.1.0
     filter:
       - mise.toml
 
@@ -88,7 +88,7 @@ assert it matches a base image) without installing the tools:
 tasks:
   - key: mise
     use: code
-    call: mise/install 1.0.1
+    call: mise/install 1.1.0
     with:
       install: "false"
     filter:

--- a/mise/install/rwx-package.yml
+++ b/mise/install/rwx-package.yml
@@ -1,25 +1,28 @@
-name: mise/install
-version: 1.0.1
-description: Install mise (mise-en-place) and the tools defined in its config
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/mise/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: mise/install
+  version: 1.1.0
+  description: Install mise (mise-en-place) and the tools defined in its config
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/mise/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  mise-version:
-    description: "Version of mise to install (e.g. 2026.7.11), or 'latest'"
-    default: "latest"
-  install:
-    description: "Run `mise install` to install the tools from the project config"
-    default: "true"
-  working-directory:
-    description: "Directory to run `mise install` in (where mise.toml/.tool-versions lives). Defaults to the RWX workspace."
-    required: false
+  parameters:
+    mise-version:
+      description: "Version of mise to install (e.g. 2026.7.11), or 'latest'"
+      default: "latest"
+    install:
+      description: "Run `mise install` to install the tools from the project config"
+      default: "true"
+    working-directory:
+      description: "Directory to run `mise install` in (where mise.toml/.tool-versions lives). Defaults to the RWX workspace."
+      required: false
 
-outputs:
-  values-from: [install]
+  outputs:
+    values-from: [install]
 
 tasks:
   - key: install
+    use: [package.use]
     run: $RWX_PACKAGE_PATH/bin/install-mise
     env:
       MISE_INSTALL_VERSION: ${{ params.mise-version }}

--- a/namespace/install-cli/README.md
+++ b/namespace/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Namespace CLI:
 ```yaml
 tasks:
   - key: namespace-cli
-    call: namespace/install-cli 1.0.2
+    call: namespace/install-cli 1.1.0
 ```
 
 To install a specific version of the Namespace CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Namespace CLI:
 ```yaml
 tasks:
   - key: namespace-cli
-    call: namespace/install-cli 1.0.2
+    call: namespace/install-cli 1.1.0
     with:
       cli-version: "0.0.437"
 ```

--- a/namespace/install-cli/rwx-package.yml
+++ b/namespace/install-cli/rwx-package.yml
@@ -1,16 +1,19 @@
-name: namespace/install-cli
-version: 1.0.2
-description: Install the Namespace CLI
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/namespace/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: namespace/install-cli
+  version: 1.1.0
+  description: Install the Namespace CLI
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/namespace/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  cli-version:
-    description: "Version of the CLI to install"
-    default: "latest"
+  parameters:
+    cli-version:
+      description: "Version of the CLI to install"
+      default: "latest"
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
 
@@ -28,3 +31,4 @@ tasks:
       nsc version
     cache:
       ttl: 1 day
+    filter: []

--- a/namespace/login-hook/README.md
+++ b/namespace/login-hook/README.md
@@ -17,7 +17,7 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login
-    call: namespace/login-hook 1.0.3
+    call: namespace/login-hook 1.1.0
     with:
       workspace-id: my-namespace-workspace-id
 
@@ -40,13 +40,13 @@ tasks:
     call: namespace/install-cli 1.0.0
 
   - key: namespace-login-to-workspace-a
-    call: namespace/login-hook 1.0.3
+    call: namespace/login-hook 1.1.0
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_A
 
   - key: namespace-login-to-workspace-b
-    call: namespace/login-hook 1.0.3
+    call: namespace/login-hook 1.1.0
     with:
       workspace-id: my-namespace-workspace-id
       oidc-token-env-name: NAMESPACE_OIDC_TOKEN_B

--- a/namespace/login-hook/rwx-package.yml
+++ b/namespace/login-hook/rwx-package.yml
@@ -1,19 +1,21 @@
-name: namespace/login-hook
-version: 1.0.3
-description: RWX hook to log in to Namespace
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/namespace/login-hook
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: namespace/login-hook
+  version: 1.1.0
+  description: RWX hook to log in to Namespace
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/namespace/login-hook
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  workspace-id:
-    description: "The Namespace workspace identifier."
-    required: true
-  oidc-token-env-name:
-    description: "The environment variable name that contains the Namespace OIDC token."
-    default: NAMESPACE_OIDC_TOKEN
-  oidc-token-path-env-name:
-    description: "The environment variable name that contains the path to the Namespace OIDC token file."
-    default: NAMESPACE_OIDC_TOKEN_PATH
+  parameters:
+    workspace-id:
+      description: "The Namespace workspace identifier."
+      required: true
+    oidc-token-env-name:
+      description: "The environment variable name that contains the Namespace OIDC token."
+      default: NAMESPACE_OIDC_TOKEN
+    oidc-token-path-env-name:
+      description: "The environment variable name that contains the path to the Namespace OIDC token file."
+      default: NAMESPACE_OIDC_TOKEN_PATH
 
 tasks:
   - key: produce-login-hooks

--- a/nodejs/install/README.md
+++ b/nodejs/install/README.md
@@ -7,7 +7,7 @@ You'll either need to specify `node-version` or `node-version-file`
 ```yaml
 tasks:
   - key: node
-    call: nodejs/install 1.1.15
+    call: nodejs/install 1.2.0
     with:
       node-version: "21.4.0"
 ```
@@ -20,7 +20,7 @@ Or with a file named `.node-version` containing the version of node to install:
 tasks:
   - key: node
     use: code # or whichever task provides the .node-version file
-    call: nodejs/install 1.1.15
+    call: nodejs/install 1.2.0
     with:
       node-version-file: .node-version
     filter:

--- a/nodejs/install/rwx-package.yml
+++ b/nodejs/install/rwx-package.yml
@@ -1,19 +1,22 @@
-name: nodejs/install
-version: 1.1.15
-description: Install Node.js, the cross-platform JavaScript runtime environment
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/nodejs/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: nodejs/install
+  version: 1.2.0
+  description: Install Node.js, the cross-platform JavaScript runtime environment
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/nodejs/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  node-version:
-    description: "Version of node to install."
-    required: false
-  node-version-file:
-    description: "Path to node version file, eg. .node-version, .nvmrc, .tool-versions."
-    required: false
+  parameters:
+    node-version:
+      description: "Version of node to install."
+      required: false
+    node-version-file:
+      description: "Path to node version file, eg. .node-version, .nvmrc, .tool-versions."
+      required: false
 
 tasks:
   - key: install
+    use: [package.use]
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if ! rwx_os_package_manager_in apt; then
@@ -22,6 +25,8 @@ tasks:
       fi
 
       $RWX_PACKAGE_PATH/bin/install-node
+    filter:
+      - '${{ params.node-version-file == "" ? "___NOMATCH" : params.node-version-file }}'
     env:
       NODE_VERSION: ${{ params.node-version }}
       NODE_VERSION_FILE: ${{ params.node-version-file }}

--- a/pagerduty/verify-signature/README.md
+++ b/pagerduty/verify-signature/README.md
@@ -5,7 +5,7 @@ Verify PagerDuty [webhook signatures](https://developer.pagerduty.com/docs/verif
 ```yaml
 tasks:
   - key: verify-signature
-    call: pagerduty/verify-signature 1.0.1
+    call: pagerduty/verify-signature 1.1.0
     with:
       body: ${{ init.body }}
       headers: ${{ init.headers }}

--- a/pagerduty/verify-signature/rwx-package.yml
+++ b/pagerduty/verify-signature/rwx-package.yml
@@ -1,22 +1,25 @@
-name: pagerduty/verify-signature
-version: 1.0.1
-description: Verify webhook signatures from PagerDuty
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/pagerduty/verify-signature
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: pagerduty/verify-signature
+  version: 1.1.0
+  description: Verify webhook signatures from PagerDuty
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/pagerduty/verify-signature
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  body:
-    description: "The body of the incoming webook"
-    required: true
-  headers:
-    description: "The headers of the incoming webhook"
-    required: true
-  shared-secret:
-    description: "The shared secret provided to you by PagerDuty upon creating the webhook"
-    required: true
+  parameters:
+    body:
+      description: "The body of the incoming webook"
+      required: true
+    headers:
+      description: "The headers of the incoming webhook"
+      required: true
+    shared-secret:
+      description: "The shared secret provided to you by PagerDuty upon creating the webhook"
+      required: true
 
 tasks:
   - key: verify
+    use: [package.use]
     run: |
       needed=""
 
@@ -39,6 +42,7 @@ tasks:
 
       SIGNATURE=$(printf '%s' "$HEADERS" | jq -r '.["x-pagerduty-signature"]')
       printf '%s' "$BODY" | $RWX_PACKAGE_PATH/verify.sh "$SHARED_SECRET" "$SIGNATURE" "v1"
+    filter: []
     env:
       BODY: ${{ params.body }}
       HEADERS: ${{ params.headers }}

--- a/python/install/README.md
+++ b/python/install/README.md
@@ -6,7 +6,7 @@ Any Python version with a precompiled binary available is supported. You'll need
 ```yaml
 tasks:
   - key: python
-    call: python/install 2.0.0
+    call: python/install 2.0.1
     with:
       python-version: 3.14.7
 ```
@@ -16,7 +16,7 @@ You can optionally specify the version of `pip` to install:
 ```yaml
 tasks:
   - key: python
-    call: python/install 2.0.0
+    call: python/install 2.0.1
     with:
       python-version: 3.14.7
       pip-version: 25.0.1
@@ -27,7 +27,7 @@ And the version of `setuptools`:
 ```yaml
 tasks:
   - key: python
-    call: python/install 2.0.0
+    call: python/install 2.0.1
     with:
       python-version: 3.14.7
       pip-version: 25.0.1
@@ -40,7 +40,7 @@ To skip verification, set `ensure-github-attestations` to `"false"`:
 ```yaml
 tasks:
   - key: python
-    call: python/install 2.0.0
+    call: python/install 2.0.1
     with:
       python-version: 3.14.7
       ensure-github-attestations: "false"

--- a/python/install/rwx-package.yml
+++ b/python/install/rwx-package.yml
@@ -1,22 +1,24 @@
-name: python/install
-version: 2.0.0
-description: Install Python, a programming language that lets you work quickly and integrate systems more effectively
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/python/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: python/install
+  version: 2.0.1
+  description: Install Python, a programming language that lets you work quickly and integrate systems more effectively
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/python/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  python-version:
-    description: "Version of Python to install"
-    required: true
-  pip-version:
-    description: "Version of pip to install"
-    required: false
-  setuptools-version:
-    description: "Version of setuptools to install"
-    required: false
-  ensure-github-attestations:
-    description: "Verify GitHub artifact attestations for the precompiled binary before installing it"
-    default: "true"
+  parameters:
+    python-version:
+      description: "Version of Python to install"
+      required: true
+    pip-version:
+      description: "Version of pip to install"
+      required: false
+    setuptools-version:
+      description: "Version of setuptools to install"
+      required: false
+    ensure-github-attestations:
+      description: "Verify GitHub artifact attestations for the precompiled binary before installing it"
+      default: true
 
 tasks:
   - key: install-python

--- a/render/deploy/README.md
+++ b/render/deploy/README.md
@@ -14,7 +14,7 @@ tasks:
 
   - key: deploy
     after: test
-    call: render/deploy 1.0.6
+    call: render/deploy 1.1.0
     with:
       ref: ${{ init.commit-sha }}
       render-api-key: ${{ vaults.your-vault.secrets.RENDER_API_KEY }}

--- a/render/deploy/rwx-package.yml
+++ b/render/deploy/rwx-package.yml
@@ -1,19 +1,21 @@
-name: render/deploy
-version: 1.0.6
-description: Deploy to Render.com
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/render/deploy
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: render/deploy
+  version: 1.1.0
+  description: Deploy to Render.com
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/render/deploy
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  ref:
-    description: "The git ref to deploy."
-    required: true
-  render-api-key:
-    description: "API key for the Render API."
-    required: true
-  service-name:
-    description: "Name of the Render service to deploy."
-    required: true
+  parameters:
+    ref:
+      description: "The git ref to deploy."
+      required: true
+    render-api-key:
+      description: "API key for the Render API."
+      required: true
+    service-name:
+      description: "Name of the Render service to deploy."
+      required: true
 
 tasks:
   - key: locate-service

--- a/ruby/install/README.md
+++ b/ruby/install/README.md
@@ -10,7 +10,7 @@ If your project has a `.ruby-version` file:
 ```yaml
 tasks:
   - key: ruby
-    call: ruby/install 2.0.0
+    call: ruby/install 2.0.1
     with:
       ruby-version-file: .ruby-version
     filter: [.ruby-version]
@@ -25,7 +25,7 @@ If your project does not have a `.ruby-version` file, you can specify the versio
 ```yaml
 tasks:
   - key: ruby
-    call: ruby/install 2.0.0
+    call: ruby/install 2.0.1
     with:
       ruby-version: 3.4.10
 ```
@@ -38,7 +38,7 @@ To skip verification, set `ensure-github-attestations` to `"false"`:
 ```yaml
 tasks:
   - key: ruby
-    call: ruby/install 2.0.0
+    call: ruby/install 2.0.1
     with:
       ruby-version: 3.4.10
       ensure-github-attestations: "false"

--- a/ruby/install/rwx-package.yml
+++ b/ruby/install/rwx-package.yml
@@ -1,22 +1,25 @@
-name: ruby/install
-version: 2.0.0
-description: Install Ruby, a dynamic programming language with a focus on simplicity and productivity
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/ruby/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: ruby/install
+  version: 2.0.1
+  description: Install Ruby, a dynamic programming language with a focus on simplicity and productivity
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/ruby/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  ruby-version:
-    description: "Version of Ruby to install"
-    required: false
-  ruby-version-file:
-    description: "File containing version of Ruby to install, commonly .ruby-version"
-    required: false
-  ensure-github-attestations:
-    description: "Verify GitHub artifact attestations for the precompiled binary before installing it"
-    default: "true"
+  parameters:
+    ruby-version:
+      description: "Version of Ruby to install"
+      required: false
+    ruby-version-file:
+      description: "File containing version of Ruby to install, commonly .ruby-version"
+      required: false
+    ensure-github-attestations:
+      description: "Verify GitHub artifact attestations for the precompiled binary before installing it"
+      default: true
 
 tasks:
   - key: install-ruby
+    use: [package.use]
     run: |
       set -u
 
@@ -124,6 +127,8 @@ tasks:
       path_to_ruby="$path_to_ruby_home/bin"
       echo "Adding $path_to_ruby to \$PATH"
       echo "$path_to_ruby" >> "$RWX_ENV/PATH"
+    filter:
+      - '${{ params.ruby-version-file == "" ? "___NOMATCH" : params.ruby-version-file }}'
     env:
       RUBY_VERSION: ${{ params.ruby-version }}
       RUBY_VERSION_FILE: ${{ params.ruby-version-file }}

--- a/rust-lang/install/README.md
+++ b/rust-lang/install/README.md
@@ -5,7 +5,7 @@ To install Rust:
 ```yaml
 tasks:
   - key: rust-lang
-    call: rust-lang/install 1.0.8
+    call: rust-lang/install 1.1.0
     with:
       rust-version: 1.83.0
 ```

--- a/rust-lang/install/rwx-package.yml
+++ b/rust-lang/install/rwx-package.yml
@@ -1,16 +1,19 @@
-name: rust-lang/install
-version: 1.0.8
-description: Install Rust, a language empowering everyone to build reliable and efficient software.
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rust-lang/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rust-lang/install
+  version: 1.1.0
+  description: Install Rust, a language empowering everyone to build reliable and efficient software.
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rust-lang/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  rust-version:
-    description: "Version of Rust to install"
-    required: true
+  parameters:
+    rust-version:
+      description: "Version of Rust to install"
+      required: true
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
 
@@ -124,5 +127,6 @@ tasks:
       rustc --version
       cargo --version
       echo "~/.cargo/bin" > "${RWX_ENV}/PATH"
+    filter: []
     env:
       RUST_VERSION: ${{ params.rust-version }}

--- a/rwx/base/README.md
+++ b/rwx/base/README.md
@@ -13,5 +13,5 @@ This package applies recommended base image configuration. It currently works wi
 ```yaml
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 ```

--- a/rwx/base/rwx-package.yml
+++ b/rwx/base/rwx-package.yml
@@ -1,8 +1,10 @@
-name: rwx/base
-version: 1.1.1
-description: The default base image configuration
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/base
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/base
+  version: 1.2.0
+  description: The default base image configuration
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/base
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
 tasks:
   - key: configure

--- a/rwx/bootstrap/rwx-package.yml
+++ b/rwx/bootstrap/rwx-package.yml
@@ -1,16 +1,19 @@
-name: rwx/bootstrap
-version: 1.5.0
-description: Used internally in RWX to bootstrap base images
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/bootstrap
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/bootstrap
+  version: 1.6.0
+  description: Used internally in RWX to bootstrap base images
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/bootstrap
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  image:
-    description: "The container image to use as a base image"
-    required: true
+  parameters:
+    image:
+      description: "The container image to use as a base image"
+      required: true
 
 tasks:
   - key: bootstrap
+    use: package.use
     run: $RWX_PACKAGE_PATH/bootstrap.sh
     env:
       IMAGE: ${{ params.image }}

--- a/rwx/bootstrap/rwx-test.yml
+++ b/rwx/bootstrap/rwx-test.yml
@@ -82,7 +82,7 @@ tasks:
       case "$NIX_PATH" in nixpkgs=/nix/store/*) ;; *) exit 1 ;; esac
       case "$SSL_CERT_FILE" in /nix/store/*/ca-bundle.crt) ;; *) exit 1 ;; esac
       # This image lists PATH twice; the last entry wins, the same as docker.
-      case "$PATH" in /root/.nix-profile/bin:/usr/bin:/bin:*) ;; *) exit 1 ;; esac
+      case "$PATH" in /opt/rwx/bin:/root/.nix-profile/bin:/usr/bin:/bin:*) ;; *) exit 1 ;; esac
 
       # Nix store paths are dr-xr-xr-x
       test "$(stat -c '%a' image/etc)" = "555"

--- a/rwx/greeting/rwx-package.yml
+++ b/rwx/greeting/rwx-package.yml
@@ -1,13 +1,15 @@
-name: rwx/greeting
-version: 1.0.6
-description: Says hello, for testing and demonstration purposes
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/greeting
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/greeting
+  version: 1.1.0
+  description: Says hello, for testing and demonstration purposes
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/greeting
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  name:
-    description: "Name to greet"
-    required: true
+  parameters:
+    name:
+      description: "Name to greet"
+      required: true
 
 tasks:
   - key: greet

--- a/rwx/install-abq/README.md
+++ b/rwx/install-abq/README.md
@@ -7,7 +7,7 @@ To install the ABQ CLI:
 ```yaml
 tasks:
   - key: abq
-    call: rwx/install-abq 1.1.10
+    call: rwx/install-abq 1.2.0
 ```
 
 ### ABQ Documentation

--- a/rwx/install-abq/rwx-package.yml
+++ b/rwx/install-abq/rwx-package.yml
@@ -1,13 +1,15 @@
-name: rwx/install-abq
-version: 1.1.10
-description: ABQ is a universal test runner that runs test suites in parallel. It’s the best tool for splitting test suites into parallel jobs in CI.
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-abq
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/install-abq
+  version: 1.2.0
+  description: ABQ is a universal test runner that runs test suites in parallel. It’s the best tool for splitting test suites into parallel jobs in CI.
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-abq
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  rwx-access-token:
-    description: "This parameter is deprecated and you do not need to pass it."
-    required: false
+  parameters:
+    rwx-access-token:
+      description: "This parameter is deprecated and you do not need to pass it."
+      required: false
 
 tasks:
   - key: install

--- a/rwx/install-captain/README.md
+++ b/rwx/install-captain/README.md
@@ -9,7 +9,7 @@ To install the latest version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.1.7
+    call: rwx/install-captain 1.2.0
 ```
 
 To install a specific version of the Captain CLI:
@@ -17,7 +17,7 @@ To install a specific version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.1.7
+    call: rwx/install-captain 1.2.0
     with:
       captain-version: v2.5.3
 ```

--- a/rwx/install-captain/rwx-package.yml
+++ b/rwx/install-captain/rwx-package.yml
@@ -1,13 +1,15 @@
-name: rwx/install-captain
-version: 1.1.7
-description: Captain is an open source CLI that can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more.
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-captain
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/install-captain
+  version: 1.2.0
+  description: Captain is an open source CLI that can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more.
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-captain
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  captain-version:
-    description: "Version of the Captain CLI to install"
-    default: "v2"
+  parameters:
+    captain-version:
+      description: "Version of the Captain CLI to install"
+      default: "v2"
 
 tasks:
   - key: install

--- a/rwx/install-cli/README.md
+++ b/rwx/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the RWX CLI:
 ```yaml
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.5
+    call: rwx/install-cli 4.1.0
 ```
 
 To install a specific version of the RWX CLI:
@@ -13,7 +13,7 @@ To install a specific version of the RWX CLI:
 ```yaml
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.5
+    call: rwx/install-cli 4.1.0
     with:
       cli-version: v3.7.0
 ```

--- a/rwx/install-cli/rwx-package.yml
+++ b/rwx/install-cli/rwx-package.yml
@@ -1,13 +1,15 @@
-name: rwx/install-cli
-version: 4.0.5
-description: Install the RWX CLI
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-cli
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/install-cli
+  version: 4.1.0
+  description: Install the RWX CLI
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/install-cli
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  cli-version:
-    description: "Version of the CLI to install"
-    default: "v3"
+  parameters:
+    cli-version:
+      description: "Version of the CLI to install"
+      default: "v3"
 
 tasks:
   - key: install

--- a/rwx/tool-versions/README.md
+++ b/rwx/tool-versions/README.md
@@ -28,7 +28,7 @@ tasks:
 
   - key: tool-versions
     use: code
-    call: rwx/tool-versions 1.0.8
+    call: rwx/tool-versions 1.1.0
     filter: [.tool-versions]
 
   - key: nodejs

--- a/rwx/tool-versions/rwx-package.yml
+++ b/rwx/tool-versions/rwx-package.yml
@@ -1,19 +1,22 @@
-name: rwx/tool-versions
-version: 1.0.8
-description: Extract tool versions from a .tool-versions file.
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/tool-versions
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/tool-versions
+  version: 1.1.0
+  description: Extract tool versions from a .tool-versions file.
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/tool-versions
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  tool-versions-file:
-    description: "Path to .tool-versions"
-    default: ".tool-versions"
+  parameters:
+    tool-versions-file:
+      description: "Path to .tool-versions"
+      default: ".tool-versions"
 
-outputs:
-  values-from: [determine-versions]
+  outputs:
+    values-from: [determine-versions]
 
 tasks:
   - key: determine-versions
+    use: [package.use]
     run: |
       sed -e 's/\s*#.*$//' -e '/^\s*$/d' -e 's/^\s\+//' "$TOOL_VERSIONS_FILE" | tr -s ' ' | cut -d' ' -f-2 | while IFS=' ' read -r tool version ; do
         name="${tool##*/}"
@@ -21,5 +24,6 @@ tasks:
         echo "$tool = $version (value: $name)"
         printf "$version" > "${RWX_VALUES}/${name}"
       done
+    filter: ["${{ params.tool-versions-file }}"]
     env:
       TOOL_VERSIONS_FILE: ${{ params.tool-versions-file }}

--- a/rwx/update-packages-github/README.md
+++ b/rwx/update-packages-github/README.md
@@ -20,7 +20,7 @@ To update minor versions (recommended):
 ```yaml
 tasks:
   - key: update-rwx-packages
-    call: rwx/update-packages-github 2.0.3
+    call: rwx/update-packages-github 2.1.0
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
@@ -32,7 +32,7 @@ Customize the label:
 ```yaml
 tasks:
   - key: update-rwx-packages
-    call: rwx/update-packages-github 2.0.3
+    call: rwx/update-packages-github 2.1.0
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
@@ -51,7 +51,7 @@ Requires repository auto-merge support.
 ```yaml
 tasks:
   - key: update-rwx-packages
-    call: rwx/update-packages-github 2.0.3
+    call: rwx/update-packages-github 2.1.0
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}

--- a/rwx/update-packages-github/rwx-package.yml
+++ b/rwx/update-packages-github/rwx-package.yml
@@ -1,46 +1,48 @@
-name: rwx/update-packages-github
-version: 2.0.3
-description: Update RWX packages for GitHub repositories
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/update-packages-github
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: rwx/update-packages-github
+  version: 2.1.0
+  description: Update RWX packages for GitHub repositories
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/rwx/update-packages-github
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  repository:
-    description: "GitHub HTTPS repository URL"
-    required: true
-  ref:
-    description: "The ref to check out of the git repository"
-    required: true
-  github-token:
-    description: "The GitHub token to a private app"
-    required: true
-  allow-major-version-change:
-    description: "Allow updating across major versions"
-    default: false
-  branch-prefix:
-    description: "Branch prefix for opened pull requests"
-    default: "rwx-update-"
-  label:
-    description: "Label for opened pull requests"
-    default: ""
-  label-color:
-    description: "Label color if not yet created"
-    default: "298F21"
-  rwx-file:
-    description: "Scope updates to a specific file or single glob pattern of files"
-  enable-auto-merge:
-    description: "Enable auto-merge on the pull request (requires repository auto-merge support)"
-    default: false
+  parameters:
+    repository:
+      description: "GitHub HTTPS repository URL"
+      required: true
+    ref:
+      description: "The ref to check out of the git repository"
+      required: true
+    github-token:
+      description: "The GitHub token to a private app"
+      required: true
+    allow-major-version-change:
+      description: "Allow updating across major versions"
+      default: false
+    branch-prefix:
+      description: "Branch prefix for opened pull requests"
+      default: "rwx-update-"
+    label:
+      description: "Label for opened pull requests"
+      default: ""
+    label-color:
+      description: "Label color if not yet created"
+      default: "298F21"
+    rwx-file:
+      description: "Scope updates to a specific file or single glob pattern of files"
+    enable-auto-merge:
+      description: "Enable auto-merge on the pull request (requires repository auto-merge support)"
+      default: false
 
 tasks:
   - key: rwx-cli
-    call: rwx/install-cli 4.0.4
+    call: rwx/install-cli 4.0.5
 
   - key: gh-cli
-    call: github/install-cli 1.0.10
+    call: github/install-cli 1.0.11
 
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: ${{ params.repository }}
       ref: ${{ params.ref }}

--- a/sonarsource/install-sonar-scanner/README.md
+++ b/sonarsource/install-sonar-scanner/README.md
@@ -11,7 +11,7 @@ tasks:
   # ... `code` task using git/clone omitted for brevity
 
   - key: sonar-scanner
-    call: sonarsource/install-sonar-scanner 1.0.5
+    call: sonarsource/install-sonar-scanner 1.1.0
     with:
       sonar-scanner-version: "6.2.1.4610"
 

--- a/sonarsource/install-sonar-scanner/rwx-package.yml
+++ b/sonarsource/install-sonar-scanner/rwx-package.yml
@@ -1,16 +1,19 @@
-name: sonarsource/install-sonar-scanner
-version: 1.0.5
-description: Install SonarSource's sonar-scanner
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/sonarsource/install-sonar-scanner
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: sonarsource/install-sonar-scanner
+  version: 1.1.0
+  description: Install SonarSource's sonar-scanner
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/sonarsource/install-sonar-scanner
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  sonar-scanner-version:
-    description: "Version of sonar-scanner to install."
-    required: true
+  parameters:
+    sonar-scanner-version:
+      description: "Version of sonar-scanner to install."
+      required: true
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
 
@@ -45,5 +48,6 @@ tasks:
       echo "Installed sonar-scanner ${SONAR_SCANNER_VERSION}"
       /opt/sonar-scanner/bin/sonar-scanner --version
       echo
+    filter: []
     env:
       SONAR_SCANNER_VERSION: ${{ params.sonar-scanner-version }}

--- a/tailscale/install/README.md
+++ b/tailscale/install/README.md
@@ -5,5 +5,5 @@ To install the latest version of Tailscale:
 ```yaml
 tasks:
   - key: tailscale
-    call: tailscale/install 1.0.7
+    call: tailscale/install 1.1.0
 ```

--- a/tailscale/install/rwx-package.yml
+++ b/tailscale/install/rwx-package.yml
@@ -1,13 +1,15 @@
-name: tailscale/install
-version: 1.0.7
-description: Install Tailscale
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/tailscale/install
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: tailscale/install
+  version: 1.1.0
+  description: Install Tailscale
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/tailscale/install
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  version:
-    description: "Version to install"
-    default: "latest"
+  parameters:
+    version:
+      description: "Version to install"
+      default: "latest"
 
 tasks:
   - key: download

--- a/twingate/setup/README.md
+++ b/twingate/setup/README.md
@@ -5,7 +5,7 @@ To install & setup the latest version of Twingate:
  ```yaml
  tasks:
    - key: twingate
-     call: twingate/setup 1.0.12
+     call: twingate/setup 1.1.0
      with:
        twingate-service-key: ${{ secrets.twingate-service-key }}
  ```

--- a/twingate/setup/rwx-package.yml
+++ b/twingate/setup/rwx-package.yml
@@ -1,16 +1,19 @@
-name: twingate/setup
-version: 1.0.12
-description: Install & setup Twingate
-source_code_url: https://github.com/rwx-cloud/packages/tree/main/twingate/setup
-issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+package:
+  name: twingate/setup
+  version: 1.1.0
+  description: Install & setup Twingate
+  source_code_url: https://github.com/rwx-cloud/packages/tree/main/twingate/setup
+  issue_tracker_url: https://github.com/rwx-cloud/packages/issues
+  visibility: public
 
-parameters:
-  twingate-service-key:
-    description: "A service key for Twingate"
-    required: true
+  parameters:
+    twingate-service-key:
+      description: "A service key for Twingate"
+      required: true
 
 tasks:
   - key: install
+    use: package.use
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       if ! rwx_os_package_manager_in apt; then
@@ -22,11 +25,13 @@ tasks:
       rwx_maybe_sudo apt-get update -yq
       rwx_maybe_sudo apt-get install -yq twingate
       rwx_maybe_sudo apt-get clean
+    filter: []
 
   - key: setup
     use: install
     run: |
       source "$RWX_PACKAGE_PATH/rwx-utils.sh"
       echo $TWINGATE_SERVICE_KEY | rwx_maybe_sudo twingate setup --headless=-
+    filter: []
     env:
       TWINGATE_SERVICE_KEY: ${{ params.twingate-service-key }}


### PR DESCRIPTION
Also cleans up the no-longer-used legacy OS testing.

I made this a minor version bump for every package because the `package.use` semantics could in principle change behavior, but it's generally unlikely and not an interface change.